### PR TITLE
Update example `createToken` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ class CheckoutForm extends React.Component {
 
     // Within the context of `Elements`, this call to createToken knows which Element to
     // tokenize, since there's only one in this group.
-    this.props.stripe.createToken({owner: {name: 'Jenny Rosen'}}).then(({token}) => {
+    this.props.stripe.createToken({name: 'Jenny Rosen'}).then(({token}) => {
       console.log('Received Stripe token:', token);
     });
 
     // However, this line of code will do the same thing:
-    // this.props.stripe.createToken({type: 'card', owner: {name: 'Jenny Rosen'}});
+    // this.props.stripe.createToken({type: 'card', name: 'Jenny Rosen'});
   }
 
   render() {


### PR DESCRIPTION
The example code uses an `owner` property which doesn't
match the [elements docs](https://stripe.com/docs/elements/reference#stripe-create-token).

r? @michelle 