### PR TITLE
Allow CSS on elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-stripe": "^1.0.10",
     "eslint-plugin-flowtype": "^2.32.1",
     "eslint-plugin-jest": "^19.0.1",
+    "eslint-plugin-jsx-a11y": "2.2.3",
     "flow-bin": "^0.44.0",
     "html-webpack-plugin": "^2.28.0",
     "jest": "^19.0.2",

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -100,7 +100,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) => class 
   }
   render() {
     return (
-      <span ref={this.handleRef} className={this.props.className} />
+      <div ref={this.handleRef} className={this.props.className} />
     );
   }
 };

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -21,6 +21,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) => class 
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
     onReady: PropTypes.func,
+    className: PropTypes.string,
   }
   static defaultProps = {
     elementRef: noop,
@@ -99,7 +100,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) => class 
   }
   render() {
     return (
-      <span ref={this.handleRef} />
+      <span ref={this.handleRef} className={this.props.className} />
     );
   }
 };

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -21,7 +21,6 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) => class 
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
     onReady: PropTypes.func,
-    className: PropTypes.string,
   }
   static defaultProps = {
     elementRef: noop,
@@ -100,7 +99,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) => class 
   }
   render() {
     return (
-      <div ref={this.handleRef} className={this.props.className} />
+      <div ref={this.handleRef}  />
     );
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,7 +1703,7 @@ eslint-plugin-jest@^19.0.1:
   version "19.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-19.0.1.tgz#42a420e90e81aa74e162c16166e43a31b890eece"
 
-eslint-plugin-jsx-a11y@^2.1.0:
+eslint-plugin-jsx-a11y@2.2.3, eslint-plugin-jsx-a11y@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz#4e35cb71b8a7db702ac415c806eb8e8d9ea6c65d"
   dependencies:


### PR DESCRIPTION
I added support for adding a a css className, and I had to switch the rendered element to a div, so that I could apply borders to the input field. My use of this in my app is as follows:

before fix:
![image](https://cloud.githubusercontent.com/assets/1278591/26165770/0468a2f0-3ae6-11e7-84a1-0652e42f3ce0.png)

after fix:
![image](https://cloud.githubusercontent.com/assets/1278591/26165953/aebda016-3ae6-11e7-9a30-e9eb721cb1e0.png)

