### PR TITLE
Allow Stripe SDK to be loaded asynchronously

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 type Props = {
   apiKey: string,
-  asyncStripeJs: boolean,
+  asyncStripeJs?: boolean,
   children?: any,
 };
 
@@ -53,7 +53,7 @@ export default class Provider extends React.Component {
   componentWillUnmount() {
     if (this._stripeJsInterval) {
       clearInterval(this._stripeJsInterval);
-      this._stripeJsInterval = null;
+      this._stripeJsInterval = 0;
     }
   }
 
@@ -77,11 +77,11 @@ export default class Provider extends React.Component {
     this._didWarn = false;
     if (this._stripeJsInterval) {
       clearInterval(this._stripeJsInterval);
-      this._stripeJsInterval = null;
+      this._stripeJsInterval = 0;
     }
   }
 
   render() {
-    return this._stripe ? React.Children.only(this.props.children) : false;
+    return this._stripe ? React.Children.only(this.props.children) : null;
   }
 }


### PR DESCRIPTION
if the `asyncStripeJs` prop is passed, and `window.Stripe` is not set, the `Provider` will not render its children and will begin checking for `window.Stripe` every 250ms.