### PR TITLE
Allow for non-Element Tokens and Sources to be created via the injected 'stripe' prop.

### DIFF
--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -10,78 +10,118 @@ type Context = FormContext & StripeContext;
 export type StripeProps = {
   createToken: Function,
   createSource: Function,
-}
+};
 
 // react-redux does a bunch of stuff with pure components / checking if it needs to re-render.
 // not sure if we need to do the same.
-const inject = <P: Object>(WrappedComponent: ReactClass<P & StripeProps>): ReactClass<P> => class extends React.Component {
-  static contextTypes = {
-    stripe: PropTypes.object.isRequired,
-    registeredElements: PropTypes.arrayOf(PropTypes.shape({
-      element: PropTypes.object.isRequired,
-      type: PropTypes.string.isRequired,
-    })),
-  }
-  static displayName = `InjectStripe(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
-
-  constructor(props: P, context: Context) {
-    if (!context || !context.registeredElements) {
-      throw new Error(
-        `It looks like you are trying to inject Stripe context outside of an Elements context.
-Please be sure the component that calls createSource or createToken is within an <Elements> component.`
-      );
-    }
-
-    super(props, context);
-  }
-
-  context: Context
-
-  stripeProps(): StripeProps {
-    return {
-      ...this.context.stripe,
-      // These are the only functions that take elements.
-      createToken: this.wrappedCreateToken,
-      createSource: this.wrappedCreateSource,
+const inject = <P: Object>(
+  WrappedComponent: ReactClass<P & StripeProps>
+): ReactClass<P> =>
+  class extends React.Component {
+    static contextTypes = {
+      stripe: PropTypes.object.isRequired,
+      registeredElements: PropTypes.arrayOf(
+        PropTypes.shape({
+          element: PropTypes.object.isRequired,
+          type: PropTypes.string.isRequired,
+        })
+      ),
     };
-  }
-  findElement = (specifiedType: mixed) => {
-    // Find the correct one!
-    const allElements = this.context.registeredElements || [];
-    const matchingElements = specifiedType && typeof specifiedType === 'string' ?
-      allElements.filter(({type}) => type === specifiedType) :
-      allElements;
+    static displayName = `InjectStripe(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
 
-    if (matchingElements.length === 1) {
-      return matchingElements[0].element;
-    } else {
-      throw new Error(
-        `You did not specify the type of Source or Token to create.
+    constructor(props: P, context: Context) {
+      if (!context || !context.registeredElements) {
+        throw new Error(
+          `It looks like you are trying to inject Stripe context outside of an Elements context.
+Please be sure the component that calls createSource or createToken is within an <Elements> component.`
+        );
+      }
+
+      super(props, context);
+    }
+
+    context: Context;
+
+    stripeProps(): StripeProps {
+      return {
+        ...this.context.stripe,
+        // These are the only functions that take elements.
+        createToken: this.wrappedCreateToken,
+        createSource: this.wrappedCreateSource,
+      };
+    }
+    // Require that exactly one Element is found.
+    requireElement = (specifiedType: string): ElementShape => {
+      const element = this.findElement(specifiedType);
+      if (element) {
+        return element;
+      } else {
+        throw new Error(
+          `You did not specify the type of Source or Token to create.
         We could not infer which Element you want to use for this operation.`
-      );
+        );
+      }
+    };
+    // Finds the element by the specified type. Throws if multiple Elements match.
+    findElement = (specifiedType: string): ?ElementShape => {
+      const allElements = this.context.registeredElements || [];
+      const matchingElements = specifiedType === 'auto'
+        ? allElements
+        : allElements.filter(({type}) => type === specifiedType);
+
+      if (matchingElements.length === 1) {
+        return matchingElements[0].element;
+      } else if (matchingElements.length > 1) {
+        throw new Error(
+          `You did not specify the type of Source or Token to create.
+        We could not infer which Element you want to use for this operation.`
+        );
+      } else {
+        return null;
+      }
+    };
+    // createToken has a bit of an unusual method signature for legacy reasons
+    // -- we're allowed to pass in the token type OR the element as the first parameter,
+    // so we need to check if we're passing in a string as the first parameter and
+    // just pass through the options if that's the case.
+    wrappedCreateToken = (typeOrOptions: mixed = {}, options: mixed = {}) => {
+      if (typeOrOptions && typeof typeOrOptions === 'object') {
+        const {type, ...rest} = typeOrOptions;
+        const specifiedType = typeof type === 'string' ? type : 'auto';
+        const element = this.requireElement(specifiedType);
+        return this.context.stripe.createToken(element, rest);
+      } else if (typeof typeOrOptions === 'string') {
+        return this.context.stripe.createToken(typeOrOptions, options);
+      } else {
+        throw new Error(
+          `Invalid options passed to createToken. Expected an object, got ${typeof options}.`
+        );
+      }
+    };
+    wrappedCreateSource = (options: mixed = {}) => {
+      if (options && typeof options === 'object') {
+        const {type, ...rest} = options; // eslint-disable-line no-unused-vars
+        const specifiedType = typeof type === 'string' ? type : 'auto';
+        const element = this.findElement(specifiedType);
+        if (element) {
+          return this.context.stripe.createSource(element, rest);
+        } else if (specifiedType !== 'auto') {
+          return this.context.stripe.createSource(options);
+        } else {
+          throw new Error(
+            `You did not specify the type of Source or Token to create.
+          We also could not find any Elements in the current context.`
+          );
+        }
+      } else {
+        throw new Error(
+          `Invalid options passed to createSource. Expected an object, got ${typeof options}.`
+        );
+      }
+    };
+    render() {
+      return <WrappedComponent {...this.props} stripe={this.stripeProps()} />;
     }
-  }
-  wrappedCreateToken = (options: mixed = {}) => {
-    if (options && typeof options === 'object') {
-      const {type, ...rest} = options;
-      const element = this.findElement(type);
-      return this.context.stripe.createToken(element, rest);
-    } else {
-      throw new Error(`Invalid options passed to createToken. Expected an object, got ${options === null ? 'null' : typeof options}.`);
-    }
-  }
-  wrappedCreateSource = (options: mixed) => {
-    if (options && typeof options === 'object') {
-      const {type, ...rest} = options; // eslint-disable-line no-unused-vars
-      const element = this.findElement(type);
-      return this.context.stripe.createSource(element, rest);
-    } else {
-      throw new Error(`Invalid options passed to createToken. Expected an object, got ${typeof options}.`);
-    }
-  }
-  render() {
-    return <WrappedComponent {...this.props} stripe={this.stripeProps()} />;
-  }
-};
+  };
 
 export default inject;

--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -1,22 +1,28 @@
+// @flow
 /* global StripeShape:false, ElementsShape:false, ElementShape:false */
 // ^For https://github.com/gajus/eslint-plugin-flowtype/issues/84
 
-// @flow
+type MixedObject = {[string]: mixed};
 
 declare type ElementShape = {
   mount: Function,
   destroy: () => ElementShape,
   on: (event: string, handler: Function) => ElementShape,
-  update: (options: Object) => ElementShape,
+  update: (options: MixedObject) => ElementShape,
 };
 
 declare type ElementsShape = {
-  create: (type: string, options: Object) => ElementShape,
+  create: (type: string, options: MixedObject) => ElementShape,
 };
 
 declare type StripeShape = {
-  elements: (options: Object) => ElementsShape,
-  createSource: (element: ElementShape | Object, options: ?Object) => Promise<{source?: Object, error?: Object}>,
-  createToken: (type: string | ElementShape, options: Object) => Promise<{token?: Object, error?: Object}>,
+  elements: (options: MixedObject) => ElementsShape,
+  createSource: (
+    element: ElementShape | MixedObject,
+    options: ?{}
+  ) => Promise<{source?: MixedObject, error?: MixedObject}>,
+  createToken: (
+    type: string | ElementShape,
+    options: mixed
+  ) => Promise<{token?: MixedObject, error?: MixedObject}>,
 };
-

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -36,69 +36,177 @@ describe('index', () => {
     window.Stripe = jest.fn().mockReturnValue(stripeMock);
   });
 
-  const MyCheckout = (props) => {
-    return (
-      <form
-        onSubmit={(ev) => {
-          ev.preventDefault();
-          props.stripe.createToken();
-        }}
-      >
-        {props.children}
-        <button>Pay</button>
-      </form>
-    );
+  const WrappedCheckout = (type, additionalOptions) => {
+    const MyCheckout = props => {
+      return (
+        <form
+          onSubmit={ev => {
+            ev.preventDefault();
+            if (type === 'token') {
+              props.stripe.createToken(additionalOptions);
+            } else {
+              props.stripe.createSource(additionalOptions);
+            }
+          }}
+        >
+          {props.children}
+          <button>Pay</button>
+        </form>
+      );
+    };
+    return injectStripe(MyCheckout);
   };
 
-  const WrappedCheckout = injectStripe(MyCheckout);
-
   it('smoke test', () => {
+    const Checkout = WrappedCheckout('token');
     const app = mount(
       <StripeProvider apiKey="pk_test_xxx">
         <Elements>
-          <WrappedCheckout>
+          <Checkout>
             Hello world
             <CardElement />
-          </WrappedCheckout>
+          </Checkout>
         </Elements>
       </StripeProvider>
     );
     expect(app.text()).toMatch(/Hello world/);
   });
 
-  it('createToken should be called when set up properly', () => {
-    const app = mount(
-      <StripeProvider apiKey="pk_test_xxx">
-        <Elements>
-          <WrappedCheckout>
-            Hello world
-            <CardElement />
-          </WrappedCheckout>
-        </Elements>
-      </StripeProvider>
-    );
-    app.find('form').simulate('submit');
-    expect(stripeMock.createToken).toHaveBeenCalledTimes(1);
-    expect(stripeMock.createToken).toHaveBeenCalledWith(elementMock, {});
+  describe('createToken', () => {
+    it('should be called when set up properly', () => {
+      const Checkout = WrappedCheckout('token');
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+              <CardElement />
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createToken).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createToken).toHaveBeenCalledWith(elementMock, {});
+    });
+
+    it('should be called when set up properly (split)', () => {
+      const Checkout = WrappedCheckout('token');
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+              <CardNumberElement />
+              <CardExpiryElement />
+              <CardCVCElement />
+              <PostalCodeElement />
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createToken).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createToken).toHaveBeenCalledWith(elementMock, {});
+    });
+
+    it('should be callable for other token types', () => {
+      const Checkout = injectStripe(props => (
+        <form
+          onSubmit={ev => {
+            ev.preventDefault();
+            props.stripe.createToken('bank_account', {some: 'data'});
+          }}
+        >
+          {props.children}
+          <button>Pay</button>
+        </form>
+      ));
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createToken).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createToken).toHaveBeenCalledWith('bank_account', {
+        some: 'data',
+      });
+    });
   });
 
-  it('createToken should be called when set up properly (split)', () => {
-    const app = mount(
-      <StripeProvider apiKey="pk_test_xxx">
-        <Elements>
-          <WrappedCheckout>
-            Hello world
-            <CardNumberElement />
-            <CardExpiryElement />
-            <CardCVCElement />
-            <PostalCodeElement />
-          </WrappedCheckout>
-        </Elements>
-      </StripeProvider>
-    );
-    app.find('form').simulate('submit');
-    expect(stripeMock.createToken).toHaveBeenCalledTimes(1);
-    expect(stripeMock.createToken).toHaveBeenCalledWith(elementMock, {});
+  describe('createSource', () => {
+    it('should be called when set up properly', () => {
+      const Checkout = WrappedCheckout('source');
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+              <CardElement />
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createSource).toHaveBeenCalledWith(elementMock, {});
+    });
+
+    it('should take additional parameters', () => {
+      const Checkout = WrappedCheckout('source', {owner: {name: 'Michelle'}});
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+              <CardElement />
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createSource).toHaveBeenCalledWith(elementMock, {
+        owner: {name: 'Michelle'},
+      });
+    });
+
+    it('should be callable for other source types', () => {
+      const Checkout = injectStripe(props => (
+        <form
+          onSubmit={ev => {
+            ev.preventDefault();
+            props.stripe.createSource({
+              type: 'three_d_secure',
+              three_d_secure: {foo: 'bar'},
+            });
+          }}
+        >
+          {props.children}
+          <button>Pay</button>
+        </form>
+      ));
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createSource).toHaveBeenCalledWith({
+        type: 'three_d_secure',
+        three_d_secure: {foo: 'bar'},
+      });
+    });
   });
 
   describe('updating props', () => {
@@ -117,32 +225,60 @@ describe('index', () => {
   describe('errors', () => {
     it('Provider should throw if Stripe is not loaded', () => {
       window.Stripe = undefined;
-      expect(() => mount(<StripeProvider apiKey="pk_test_xxx" />)).toThrowError(/js.stripe.com\/v3/);
-    });
-
-    it('createToken should throw when not in Elements', () => {
-      expect(() => mount(
-        <StripeProvider apiKey="pk_test_xxx">
-          <WrappedCheckout>
-            <Elements>
-              <CardElement />
-            </Elements>
-          </WrappedCheckout>
-        </StripeProvider>
-      )).toThrowError('Elements context');
-    });
-
-    it('createToken should throw when no Element found', () => {
-      const app = mount(
-        <StripeProvider apiKey="pk_test_xxx">
-          <Elements>
-            <WrappedCheckout>
-              Hello world
-            </WrappedCheckout>
-          </Elements>
-        </StripeProvider>
+      expect(() => mount(<StripeProvider apiKey="pk_test_xxx" />)).toThrowError(
+        /js.stripe.com\/v3/
       );
-      expect(() => app.find('form').simulate('submit')).toThrowError(/did not specify/);
+    });
+
+    describe('createSource', () => {
+      it('should throw when no Element found', () => {
+        const Checkout = WrappedCheckout('source');
+        const app = mount(
+          <StripeProvider apiKey="pk_test_xxx">
+            <Elements>
+              <Checkout>
+                Hello world
+              </Checkout>
+            </Elements>
+          </StripeProvider>
+        );
+        expect(() => app.find('form').simulate('submit')).toThrowError(
+          /did not specify/
+        );
+      });
+    });
+
+    describe('createToken', () => {
+      it('should throw when not in Elements', () => {
+        const Checkout = WrappedCheckout('token');
+        expect(() =>
+          mount(
+            <StripeProvider apiKey="pk_test_xxx">
+              <Checkout>
+                <Elements>
+                  <CardElement />
+                </Elements>
+              </Checkout>
+            </StripeProvider>
+          )
+        ).toThrowError('Elements context');
+      });
+
+      it('should throw when no Element found', () => {
+        const Checkout = WrappedCheckout('token');
+        const app = mount(
+          <StripeProvider apiKey="pk_test_xxx">
+            <Elements>
+              <Checkout>
+                Hello world
+              </Checkout>
+            </Elements>
+          </StripeProvider>
+        );
+        expect(() => app.find('form').simulate('submit')).toThrowError(
+          /did not specify/
+        );
+      });
     });
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -37,10 +37,10 @@ describe('index', () => {
   });
 
   const WrappedCheckout = (type, additionalOptions) => {
-    const MyCheckout = props => {
+    const MyCheckout = (props) => {
       return (
         <form
-          onSubmit={ev => {
+          onSubmit={(ev) => {
             ev.preventDefault();
             if (type === 'token') {
               props.stripe.createToken(additionalOptions);
@@ -111,9 +111,9 @@ describe('index', () => {
     });
 
     it('should be callable for other token types', () => {
-      const Checkout = injectStripe(props => (
+      const Checkout = injectStripe((props) => (
         <form
-          onSubmit={ev => {
+          onSubmit={(ev) => {
             ev.preventDefault();
             props.stripe.createToken('bank_account', {some: 'data'});
           }}
@@ -177,9 +177,9 @@ describe('index', () => {
     });
 
     it('should be callable for other source types', () => {
-      const Checkout = injectStripe(props => (
+      const Checkout = injectStripe((props) => (
         <form
-          onSubmit={ev => {
+          onSubmit={(ev) => {
             ev.preventDefault();
             props.stripe.createSource({
               type: 'three_d_secure',


### PR DESCRIPTION
Based off of #31 -- fixes #28 and #29. cc @dagfs
r? @dotch 

### Summary

More granular checks for what what the developer wants us to do when they call `createSource` or `createToken`, so that we allow for non-Element Source and Token creation.
- If no `type` is passed, we assume that we need to look for an Element.
- If a `type` is passed but we find no matching Element, we pass the data blob on to Stripe.js

### Testing

Added some unit tests for the cases we care about.