### PR TITLE
Allow using <*Element> within collapsible component

### DIFF
--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -56,15 +56,15 @@ export default class Elements extends React.Component {
   _elements: ElementsShape
 
   handleRegisterElement = (type: string, element: Object) => {
-    this.setState({
-      registeredElements: [...this.state.registeredElements, {type, element}],
-    });
+    this.setState((prevState) => ({
+      registeredElements: [...prevState.registeredElements, {type, element}],
+    }));
   }
 
   handleUnregisterElement = (el: Object) => {
-    this.setState({
-      registeredElements: this.state.registeredElements.filter(({element}) => element !== el),
-    });
+    this.setState((prevState) => ({
+      registeredElements: prevState.registeredElements.filter(({element}) => element !== el),
+    }));
   }
 
   render() {


### PR DESCRIPTION
When I allow users to show/hide form with Stripe elements, stripe will not create a token.

>You did not specify the type of Source or Token to create

During debugging I noticed that elements are not unregistered correctly, so every time users unhide the form it adds new element with `type: card`. So this code doesn't operate well.

Everything we need is just to set state with supporting of asynchronous way.

Let me know if you need an example or more details.