### PR TITLE
Allow `*Element` components to take `className`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ These components accept all `options` that can be passed into `elements.create(t
 
 ```js
 type ElementProps = {
+  className?: string,
   elementRef?: (StripeElement) => void,
 
   // For full documentation on the events and payloads below, see:

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -5,6 +5,7 @@ import shallowEqual from '../utils/shallowEqual';
 import type {ElementContext} from './Elements';
 
 type Props = {
+  className: string,
   elementRef: Function,
   onChange: Function,
   onBlur: Function,
@@ -17,6 +18,7 @@ const noop = () => {};
 const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
   class extends React.Component {
     static propTypes = {
+      className: PropTypes.string,
       elementRef: PropTypes.func,
       onChange: PropTypes.func,
       onBlur: PropTypes.func,
@@ -24,6 +26,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
       onReady: PropTypes.func,
     };
     static defaultProps = {
+      className: '',
       elementRef: noop,
       onChange: noop,
       onBlur: noop,
@@ -88,6 +91,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
 
     _extractOptions(props: Props): Object {
       const {
+        className,
         elementRef,
         onChange,
         onFocus,
@@ -102,7 +106,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
       this._ref = ref;
     };
     render() {
-      return <span ref={this.handleRef} />;
+      return <span className={this.props.className} ref={this.handleRef} />;
     }
   };
 

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -1,6 +1,6 @@
 // @noflow
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 
 import Element from './Element';
 
@@ -23,6 +23,13 @@ describe('Element', () => {
       registerElement: jest.fn(),
       unregisterElement: jest.fn(),
     };
+  });
+
+  it('should pass className to the DOM element', () => {
+    const className = 'my-class';
+    const CardElement = Element('card', {sourceType: 'card'});
+    const element = shallow(<CardElement className={className} />, {context});
+    expect(element.first().hasClass(className)).toBeTruthy();
   });
 
   it('should call the right hooks for a source Element', () => {


### PR DESCRIPTION
r? @michelle 

### Summary

Allow `*Element` components to take `className`.

Fixes #51.

### Motivation

Per our docs, we suggest users apply existing input classes to element-container DOM elements.

### Testing

Added a unit test.