### PR TITLE
Render *Element components with div instead of span

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -106,7 +106,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
       this._ref = ref;
     };
     render() {
-      return <span className={this.props.className} ref={this.handleRef} />;
+      return <div className={this.props.className} ref={this.handleRef} />;
     }
   };
 


### PR DESCRIPTION
This is based on the [confusion](https://github.com/stripe/react-stripe-elements/pull/57) I had when trying to apply a custom class to one of these components.