### PR TITLE
Consistent JS object-dereference style

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ let's add `StripeProvider` to our root React App component:
 ```js
 // index.js
 import React from 'react';
-import { render } from 'react-dom';
+import {render} from 'react-dom';
 import {StripeProvider} from 'react-stripe-elements';
 
 import MyStoreCheckout from './MyStoreCheckout';


### PR DESCRIPTION
The example code in the readme uses both `{foo}` and `{ foo }`. The former is used more frequently, so I changed the one instance of the latter.