### PR TITLE
Allow to customize the stripe factory

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -24,7 +24,7 @@ const defaultStripeFactory = (props: Props): StripeShape => {
   const { apiKey, children, ...options } = props;
 
   return window.Stripe(apiKey, options);
-}
+};
 
 export default class Provider extends React.Component<Props> {
   // Even though we're using flow, also use PropTypes so we can take advantage of developer warnings.

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -9,7 +9,7 @@ type StripeFactoryProps = {
 
 export type StripeFactory = (props: StripeFactoryProps) => StripeShape;
 
-type Props = StripeFactoryProps | {
+type Props = StripeFactoryProps & {
   stripeFactory: StripeFactory,
 };
 

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -2,19 +2,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-type Props = {
+type StripeFactoryProps = {
   apiKey: string,
+};
+
+export type StripeFactory = (props: StripeFactoryProps) => StripeShape;
+
+type Props = StripeFactoryProps | {
   children?: any,
-  stripeFactory: StripeFactory;
+  stripeFactory: StripeFactory,
 };
 
 export type StripeContext = {
   stripe: StripeShape,
 };
 
-export type StripeFactory = (props: Props) => StripeShape;
-
-const defaultStripeFactory = (props: Props): StripeShape => {
+const defaultStripeFactory = (props: StripeFactoryProps): StripeShape => {
   if (!window.Stripe) {
     throw new Error(
       'Please load Stripe.js (https://js.stripe.com/v3/) on this page to use react-stripe-elements.'

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 
 type StripeFactoryProps = {
   apiKey: string,
-  children?: any,
 };
 
 export type StripeFactory = (props: StripeFactoryProps) => StripeShape;
 
 type Props = StripeFactoryProps & {
   stripeFactory: StripeFactory,
+  children?: any,
 };
 
 export type StripeContext = {
@@ -24,7 +24,7 @@ const defaultStripeFactory = (props: StripeFactoryProps): StripeShape => {
     );
   }
 
-  const { apiKey, children, ...options } = props;
+  const { apiKey, ...options } = props;
 
   return window.Stripe(apiKey, options);
 };
@@ -47,7 +47,9 @@ export default class Provider extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
 
-    this._stripe = props.stripeFactory(props);
+    const { stripeFactory, children, ...factoryProps } = this.props;
+
+    this._stripe = stripeFactory(factoryProps);
     this._didWarn = false;
   }
 

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -14,7 +14,7 @@ export type StripeContext = {
 
 export type StripeFactory = (props: Props) => StripeShape;
 
-function defaultStripeFactory(props: Props): StripeShape {
+const defaultStripeFactory = (props: Props): StripeShape => {
   if (!window.Stripe) {
     throw new Error(
       'Please load Stripe.js (https://js.stripe.com/v3/) on this page to use react-stripe-elements.'

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -24,7 +24,7 @@ const defaultStripeFactory = (props: StripeFactoryProps): StripeShape => {
     );
   }
 
-  const { apiKey, ...options } = props;
+  const {apiKey, ...options} = props;
 
   return window.Stripe(apiKey, options);
 };
@@ -47,7 +47,7 @@ export default class Provider extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
 
-    const { stripeFactory, children, ...factoryProps } = this.props;
+    const {stripeFactory, children, ...factoryProps} = this.props;
 
     this._stripe = stripeFactory(factoryProps);
     this._didWarn = false;

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -5,37 +5,44 @@ import PropTypes from 'prop-types';
 type Props = {
   apiKey: string,
   children?: any,
+  stripeFactory: Function;
 };
 
 export type StripeContext = {
   stripe: StripeShape,
 };
 
+function defaultStripeFactory(props: Props): StripeShape {
+  if (!window.Stripe) {
+    throw new Error(
+      'Please load Stripe.js (https://js.stripe.com/v3/) on this page to use react-stripe-elements.'
+    );
+  }
+
+  const { apiKey, children, ...options } = props;
+
+  return window.Stripe(apiKey, options);
+}
+
 export default class Provider extends React.Component<Props> {
   // Even though we're using flow, also use PropTypes so we can take advantage of developer warnings.
   static propTypes = {
     apiKey: PropTypes.string.isRequired,
     children: PropTypes.node,
+    stripeFactory: PropTypes.func.isRequired,
   };
   static childContextTypes = {
     stripe: PropTypes.object.isRequired,
   };
   static defaultProps = {
     children: null,
+    stripeFactory: defaultStripeFactory,
   };
 
   constructor(props: Props) {
     super(props);
 
-    if (!window.Stripe) {
-      throw new Error(
-        'Please load Stripe.js (https://js.stripe.com/v3/) on this page to use react-stripe-elements.'
-      );
-    }
-
-    const {apiKey, children, ...options} = this.props;
-
-    this._stripe = window.Stripe(apiKey, options);
+    this._stripe = props.stripeFactory(props);
     this._didWarn = false;
   }
 

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -5,12 +5,14 @@ import PropTypes from 'prop-types';
 type Props = {
   apiKey: string,
   children?: any,
-  stripeFactory: Function;
+  stripeFactory: StripeFactory;
 };
 
 export type StripeContext = {
   stripe: StripeShape,
 };
+
+export type StripeFactory = (props: Props) => StripeShape;
 
 function defaultStripeFactory(props: Props): StripeShape {
   if (!window.Stripe) {

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types';
 
 type StripeFactoryProps = {
   apiKey: string,
+  children?: any,
 };
 
 export type StripeFactory = (props: StripeFactoryProps) => StripeShape;
 
 type Props = StripeFactoryProps | {
-  children?: any,
   stripeFactory: StripeFactory,
 };
 

--- a/src/components/Provider.test.js
+++ b/src/components/Provider.test.js
@@ -114,4 +114,15 @@ describe('StripeProvider', () => {
     );
     global.console.error = originalConsoleError;
   });
+
+  it('supports custom stripe factory', () => {
+    const mockStripeFactory = jest.fn();
+    mockStripeFactory.mockReturnValue({});
+    shallow(
+      <StripeProvider apiKey="made_up_key" foo="bar" stripeFactory={mockStripeFactory}>
+        <form />
+      </StripeProvider>
+    );
+    expect(mockStripeFactory).toHaveBeenCalledWith({ apiKey: 'made_up_key', foo: 'bar' });
+  });
 });

--- a/src/components/Provider.test.js
+++ b/src/components/Provider.test.js
@@ -119,10 +119,17 @@ describe('StripeProvider', () => {
     const mockStripeFactory = jest.fn();
     mockStripeFactory.mockReturnValue({});
     shallow(
-      <StripeProvider apiKey="made_up_key" foo="bar" stripeFactory={mockStripeFactory}>
+      <StripeProvider
+        apiKey="made_up_key"
+        foo="bar"
+        stripeFactory={mockStripeFactory}
+      >
         <form />
       </StripeProvider>
     );
-    expect(mockStripeFactory).toHaveBeenCalledWith({ apiKey: 'made_up_key', foo: 'bar' });
+    expect(mockStripeFactory).toHaveBeenCalledWith({
+      apiKey: 'made_up_key',
+      foo: 'bar',
+    });
   });
 });


### PR DESCRIPTION
In order to use my own Stripe instance with this library, I want to be able to inject it into the provider. To make it flexible, I propose to expose the `stripeFactory` property.