### PR TITLE
Remove proptypes warning by importing only React from React

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import shallowEqual from '../utils/shallowEqual';
 import type {ElementContext} from './Elements';

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import type {StripeContext} from './Provider';
 

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -1,7 +1,8 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
+import type {ComponentType} from 'react';
 import type {FormContext} from './Elements';
 import type {StripeContext} from './Provider';
 
@@ -19,9 +20,9 @@ export type StripeProps = {
 // react-redux does a bunch of stuff with pure components / checking if it needs to re-render.
 // not sure if we need to do the same.
 const inject = <Props: {}>(
-  WrappedComponent: React.ComponentType<{stripe: StripeProps} & Props>,
+  WrappedComponent: ComponentType<{stripe: StripeProps} & Props>,
   componentOptions: Options = {}
-): React.ComponentType<Props> => {
+): ComponentType<Props> => {
   const {withRef = false} = componentOptions;
 
   return class extends React.Component<Props, any> {


### PR DESCRIPTION
Some of the modules were using the namespace import syntax for the React package, which was causing console warnings against importing `PropTypes`.

<img width="2047" alt="screen shot 2017-09-21 at 11 55 45 am" src="https://user-images.githubusercontent.com/3409645/30713582-942c9e4a-9ec4-11e7-92d6-ce7b621c7cd2.png">

This has been fixed by only importing React from React. If other objects are needed from React, either import them as named imports or pull them off the default import object.