### PR TITLE
eslint rule parity with stripe-js-v3

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,8 +14,8 @@ env:
   jest/globals: true
 rules:
   react/jsx-filename-extension: 0
-  no-duplicate-imports: 0 # doesn't support flow imports.
-  no-console: 1 # disable this while undergoing lots of development.
+  no-duplicate-imports: 2 # doesn't support flow imports.
+  no-console: 0
   func-style: 2
   arrow-parens:
     - 2
@@ -25,6 +25,7 @@ rules:
     - 2
     - allowNamedFunctions: false
       allowUnboundThis: false
+  flowtype/no-primitive-constructor-types: 2
   flowtype/require-valid-file-annotation:
     - 2
     - 'always'

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -1,8 +1,7 @@
 // @flow
-import React from 'react';
+import React, {type ComponentType} from 'react';
 import PropTypes from 'prop-types';
 
-import type {ComponentType} from 'react';
 import type {FormContext} from './Elements';
 import type {StripeContext} from './Provider';
 


### PR DESCRIPTION
r? @cweiss

In particular, turns on the rule for only one import line for a package.