### PR TITLE
Made all functional props nullable

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -6,14 +6,12 @@ import type {ElementContext} from './Elements';
 
 type Props = {
   className: string,
-  elementRef: Function,
-  onChange: Function,
-  onBlur: Function,
-  onFocus: Function,
-  onReady: Function,
+  elementRef: ?Function,
+  onChange: ?Function,
+  onBlur: ?Function,
+  onFocus: ?Function,
+  onReady: ?Function,
 };
-
-const noop = () => {};
 
 const _extractOptions = (props: Props): Object => {
   const {
@@ -40,11 +38,11 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
     };
     static defaultProps = {
       className: '',
-      elementRef: noop,
-      onChange: noop,
-      onBlur: noop,
-      onFocus: noop,
-      onReady: noop,
+      elementRef: undefined,
+      onChange: undefined,
+      onBlur: undefined,
+      onFocus: undefined,
+      onReady: undefined,
     };
 
     static contextTypes = {
@@ -90,16 +88,22 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
 
     _setupEventListeners() {
       this._element.on('ready', () => {
-        this.props.elementRef(this._element);
-        this.props.onReady();
+        this.props.elementRef && this.props.elementRef(this._element);
+        this.props.onReady && this.props.onReady();
       });
 
       this._element.on('change', change => {
-        this.props.onChange(change);
+        this.props.onChange && this.props.onChange(change);
       });
 
-      this._element.on('blur', (...args) => this.props.onBlur(...args));
-      this._element.on('focus', (...args) => this.props.onFocus(...args));
+      this._element.on(
+        'blur',
+        (...args) => this.props.onBlur && this.props.onBlur(...args)
+      );
+      this._element.on(
+        'focus',
+        (...args) => this.props.onFocus && this.props.onFocus(...args)
+      );
     }
 
     handleRef = (ref: ?HTMLElement) => {


### PR DESCRIPTION
I have a case when I need to clone an `<*Element />` component with overriding of its properties with less priority. For example:

```js
import React from 'react';

function SmartElement({ children }) {
  return React.cloneElement(children, { onChange: () => console.log('change'), ...children.props });
}
```

In this case, my `onChange` will not be called because of `defaultProps.onChange` of the `*Element`. So `{ ...{ onChange: myFunc }, ...{ onChange: noop } }` will return `{ onChange: noop }`.

A real use case:

https://github.com/callemall/material-ui/blob/v0.19.2/src/TextField/TextField.js#L462-L467

```js
const inputProps = {
  id: inputId,
  ref: (elem) => this.input = elem,
  disabled: this.props.disabled,
  onBlur: this.handleInputBlur,
  onChange: this.handleInputChange,
  onFocus: this.handleInputFocus,
};

// ...

inputElement = React.cloneElement(children, {
  ...inputProps,
  ...children.props, // it overrides `inputProps`
  style: Object.assign(childStyleMerged, children.props.style),
});
```

Usage:

```js
<TextField>
  <CardNumberElement />
</TextField>
```