### PR TITLE
Use cached instance of Stripe if available.

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -35,7 +35,13 @@ export default class Provider extends React.Component<Props> {
 
     const {apiKey, children, ...options} = this.props;
 
-    this._stripe = window.Stripe(apiKey, options);
+    window.Stripe.__cachedInstances = window.Stripe.__cachedInstances || {};
+    const cacheKey = `key=${apiKey} options=${JSON.stringify(options)}`;
+    this._stripe =
+      window.Stripe.__cachedInstances[cacheKey] ||
+      window.Stripe(apiKey, options);
+    window.Stripe.__cachedInstances[cacheKey] = this._stripe;
+
     this._didWarn = false;
   }
 

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -35,6 +35,12 @@ export default class Provider extends React.Component<Props> {
 
     const {apiKey, children, ...options} = this.props;
 
+    /**
+     * Note that this is not meant to be a generic memoization solution.
+     * This is specifically a solution for `StripeProvider`s being initialized
+     * and destroyed regularly (with the same set of props) when users only
+     * use `StripeProvider` for the subtree that contains their checkout form.
+     */
     window.Stripe.__cachedInstances = window.Stripe.__cachedInstances || {};
     const cacheKey = `key=${apiKey} options=${JSON.stringify(options)}`;
     this._stripe =

--- a/src/components/Provider.test.js
+++ b/src/components/Provider.test.js
@@ -99,6 +99,38 @@ describe('StripeProvider', () => {
     expect(childContext).toEqual({stripe: stripeMockResult});
   });
 
+  it('does not create a new Stripe instance if one exists for the same key', () => {
+    window.Stripe = jest.fn(() => ({}));
+
+    // First, create the first instance.
+    let wrapper = mount(
+      <StripeProvider apiKey="key_one">
+        <form />
+      </StripeProvider>
+    );
+    let childContext = wrapper.node.getChildContext();
+    const keyOneInstance = childContext.stripe;
+    expect(keyOneInstance).toBeTruthy();
+
+    // Create another!
+    wrapper = mount(
+      <StripeProvider apiKey="key_one">
+        <form />
+      </StripeProvider>
+    );
+    childContext = wrapper.node.getChildContext();
+    expect(childContext.stripe).toBe(keyOneInstance);
+
+    // Create another, but with a different key!
+    wrapper = mount(
+      <StripeProvider apiKey="key_two">
+        <form />
+      </StripeProvider>
+    );
+    childContext = wrapper.node.getChildContext();
+    expect(childContext.stripe).not.toBe(keyOneInstance);
+  });
+
   it('warns when trying to change the API key', () => {
     const originalConsoleError = global.console.error;
     const mockConsoleError = jest.fn();


### PR DESCRIPTION
r? @jenan-stripe || @cweiss-stripe 

#### Summary

Because it's common in React to re-render entire subtrees pretty regularly & `StripeProvider` manages the `Stripe` instance in this library, let's keep a cache of `Stripe` instances and use one with a matching configuration if it exists.

#### Motivation

https://github.com/stripe/react-stripe-elements/issues/99

#### Test plan

Wrote tests + tested manually on an integration.

