### PR TITLE
Add on('click') event to PaymentRequestButtonElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,10 @@ type ElementProps = {
 
   // For full documentation on the events and payloads below, see:
   // https://stripe.com/docs/elements/reference#element-on
-  onChange?: (changeObject: Object) => void,
-  onReady?: () => void,
-  onFocus?: () => void,
   onBlur?: () => void,
+  onChange?: (changeObject: Object) => void,
+  onFocus?: () => void,
+  onReady?: () => void,
 };
 ```
 
@@ -303,9 +303,10 @@ type PaymentRequestButtonProps = {
   className?: string,
   elementRef?: (StripeElement) => void,
 
-  onReady?: () => void,
-  onFocus?: () => void,
   onBlur?: () => void,
+  onClick?: () => void,
+  onFocus?: () => void,
+  onReady?: () => void,
 };
 ```
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -17,14 +17,17 @@ import {
   injectStripe,
 } from '../src/index';
 
+const handleBlur = () => {
+  console.log('[blur]');
+};
 const handleChange = change => {
   console.log('[change]', change);
 };
+const handleClick = () => {
+  console.log('[click]');
+};
 const handleFocus = () => {
   console.log('[focus]');
-};
-const handleBlur = () => {
-  console.log('[blur]');
 };
 const handleReady = () => {
   console.log('[ready]');
@@ -63,9 +66,9 @@ class _CardForm extends React.Component<{
         <label>
           Card details
           <CardElement
+            onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}
-            onBlur={handleBlur}
             onReady={handleReady}
             {...createOptions(this.props.fontSize)}
           />
@@ -91,9 +94,9 @@ class _SplitForm extends React.Component<{
         <label>
           Card number
           <CardNumberElement
+            onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}
-            onBlur={handleBlur}
             onReady={handleReady}
             {...createOptions(this.props.fontSize)}
           />
@@ -101,9 +104,9 @@ class _SplitForm extends React.Component<{
         <label>
           Expiration date
           <CardExpiryElement
+            onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}
-            onBlur={handleBlur}
             onReady={handleReady}
             {...createOptions(this.props.fontSize)}
           />
@@ -111,9 +114,9 @@ class _SplitForm extends React.Component<{
         <label>
           CVC
           <CardCVCElement
+            onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}
-            onBlur={handleBlur}
             onReady={handleReady}
             {...createOptions(this.props.fontSize)}
           />
@@ -121,9 +124,9 @@ class _SplitForm extends React.Component<{
         <label>
           Postal code
           <PostalCodeElement
+            onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}
-            onBlur={handleBlur}
             onReady={handleReady}
             {...createOptions(this.props.fontSize)}
           />
@@ -178,8 +181,12 @@ class _PaymentRequestForm extends React.Component<
   render() {
     return this.state.canMakePayment ? (
       <PaymentRequestButtonElement
-        paymentRequest={this.state.paymentRequest}
         className="PaymentRequestButton"
+        onBlur={handleBlur}
+        onClick={handleClick}
+        onFocus={handleFocus}
+        onReady={handleReady}
+        paymentRequest={this.state.paymentRequest}
         style={{
           paymentRequestButton: {
             theme: 'dark',

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -72,13 +72,13 @@ class PaymentRequestButtonElement extends React.Component<Props> {
       ...options,
     });
     this._options = options;
-    this._element.on('blur', (...args) => this.props.onBlur(...args));
-    this._element.on('click', (...args) => this.props.onClick(...args));
-    this._element.on('focus', (...args) => this.props.onFocus(...args));
     this._element.on('ready', () => {
       this.props.elementRef(this._element);
       this.props.onReady();
     });
+    this._element.on('focus', (...args) => this.props.onFocus(...args));
+    this._element.on('click', (...args) => this.props.onClick(...args));
+    this._element.on('blur', (...args) => this.props.onBlur(...args));
   }
 
   componentDidMount() {

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -8,6 +8,7 @@ type Props = {
   className: string,
   elementRef: Function,
   onBlur: Function,
+  onClick: Function,
   onFocus: Function,
   onReady: Function,
   paymentRequest: {
@@ -23,10 +24,11 @@ const _extractOptions = (props: Props): Object => {
   const {
     className,
     elementRef,
-    paymentRequest,
-    onReady,
-    onFocus,
     onBlur,
+    onClick,
+    onFocus,
+    onReady,
+    paymentRequest,
     ...options
   } = props;
   return options;
@@ -37,6 +39,7 @@ class PaymentRequestButtonElement extends React.Component<Props> {
     className: PropTypes.string,
     elementRef: PropTypes.func,
     onBlur: PropTypes.func,
+    onClick: PropTypes.func,
     onFocus: PropTypes.func,
     onReady: PropTypes.func,
     paymentRequest: PropTypes.shape({
@@ -49,6 +52,7 @@ class PaymentRequestButtonElement extends React.Component<Props> {
     className: '',
     elementRef: noop,
     onBlur: noop,
+    onClick: noop,
     onFocus: noop,
     onReady: noop,
   };
@@ -68,12 +72,13 @@ class PaymentRequestButtonElement extends React.Component<Props> {
       ...options,
     });
     this._options = options;
+    this._element.on('blur', (...args) => this.props.onBlur(...args));
+    this._element.on('click', (...args) => this.props.onClick(...args));
+    this._element.on('focus', (...args) => this.props.onFocus(...args));
     this._element.on('ready', () => {
       this.props.elementRef(this._element);
       this.props.onReady();
     });
-    this._element.on('blur', (...args) => this.props.onBlur(...args));
-    this._element.on('focus', (...args) => this.props.onFocus(...args));
   }
 
   componentDidMount() {


### PR DESCRIPTION
Adds support for the `paymentRequestButton.on('click')` event to the `PaymentRequestButtonElement`. Documentation for the event can be found here: https://stripe.com/docs/stripe.js#element-on.

Also reorders event handler parameters in various places to be in alphabetical order.

Tested by logging click events on the demo page and making sure they are fired.