### PR TITLE
Use ES module system for es version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,18 @@
 {
-  "presets": ["react", "es2015"],
-  "plugins": ["transform-class-properties", "transform-object-rest-spread"]
+  "env": {
+    "commonjs": {
+      "plugins": ["transform-class-properties", "transform-object-rest-spread"],
+      "presets": [
+        "react",
+        "es2015"
+      ]
+    },
+    "es": {
+      "plugins": ["transform-class-properties", "transform-object-rest-spread"],
+      "presets": [
+        "react",
+        ["es2015", {"modules": false}]
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "scripts": {
-    "test": "node_modules/.bin/jest",
+    "test": "cross-env NODE_ENV=commonjs node_modules/.bin/jest",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack src/index.js dist/react-stripe-elements.js --config webpack.config.prod.js",
@@ -20,6 +20,9 @@
     "prepublish": "yarn run clean && yarn run build",
     "demo": "webpack-dev-server --content-base dist",
     "doctoc": "doctoc README.md"
+  },
+  "jest": {
+    "testRegex": "(/src/.*\\.test.js)$"
   },
   "keywords": [],
   "author": "Stripe (https://www.stripe.com)",


### PR DESCRIPTION
### Summary & motivation

The motivation of providing `jsnext:main` and `module` values in `package.json` is to allow libraries to declare where to find a version of their code that uses the ES module system (`import` and `export`, rather than CJS `require`) to allow tree-shaking and other static optimizations. (Despite being called "jsnext", all non-ES5 features other than the module system _are_ supposed to be compiled away.

Currently, we provide these values and point to the `es` build, but this build actually has CJS-style `require` calls instead of `import`, so it isn't of any benefit to consumers of this library.

This PR configures our es build to leave in ES modules. It also changes some test config so jest doesn't run all the different built versions of our tests.

### API review

The only API chance is that consumers of this library can now do static analysis and get tree-shaking (and maybe scope hoisting?) of our exported ES module code.

### Testing & documentation

- Ran the es build and only change was modules still being in ES.
- Unit tests still pass.