### PR TITLE
Correct bug with pure components

### DIFF
--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -3,8 +3,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import type {StripeContext} from './Provider';
 
+type ElementsList = Array<{type: string, element: ElementShape}>;
+
 type Props = {
   children?: any,
+};
+
+type State = {
+  registeredElements: ElementsList,
+};
+
+export type InjectContext = {
+  getRegisteredElements: () => ElementsList,
 };
 
 export type ElementContext = {
@@ -12,22 +22,15 @@ export type ElementContext = {
   registerElement: (type: string, element: ElementShape) => void,
   unregisterElement: (element: ElementShape) => void,
 };
-export type FormContext = {
-  registeredElements: Array<{type: string, element: ElementShape}>,
-};
-type ElementsContext = ElementContext & FormContext;
 
-export default class Elements extends React.Component<Props, FormContext> {
+type Context = InjectContext & ElementContext;
+
+export default class Elements extends React.Component<Props, State> {
   static childContextTypes = {
     elements: PropTypes.object.isRequired,
     registerElement: PropTypes.func.isRequired,
     unregisterElement: PropTypes.func.isRequired,
-    registeredElements: PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.string.isRequired,
-        element: PropTypes.object.isRequired,
-      })
-    ).isRequired,
+    getRegisteredElements: PropTypes.func.isRequired,
   };
   static contextTypes = {
     stripe: PropTypes.object.isRequired,
@@ -46,12 +49,12 @@ export default class Elements extends React.Component<Props, FormContext> {
     };
   }
 
-  getChildContext(): ElementsContext {
+  getChildContext(): Context {
     return {
       elements: this._elements,
       registerElement: this.handleRegisterElement,
       unregisterElement: this.handleUnregisterElement,
-      registeredElements: this.state.registeredElements,
+      getRegisteredElements: () => this.state.registeredElements,
     };
   }
   props: Props;

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -2,10 +2,10 @@
 import React, {type ComponentType} from 'react';
 import PropTypes from 'prop-types';
 
-import type {FormContext} from './Elements';
+import type {InjectContext} from './Elements';
 import type {StripeContext} from './Provider';
 
-type Context = FormContext & StripeContext;
+type Context = InjectContext & StripeContext;
 
 type Options = {
   withRef?: boolean,
@@ -27,19 +27,14 @@ const inject = <Props: {}>(
   return class extends React.Component<Props, any> {
     static contextTypes = {
       stripe: PropTypes.object.isRequired,
-      registeredElements: PropTypes.arrayOf(
-        PropTypes.shape({
-          element: PropTypes.object.isRequired,
-          type: PropTypes.string.isRequired,
-        })
-      ),
+      getRegisteredElements: PropTypes.func,
     };
     static displayName = `InjectStripe(${WrappedComponent.displayName ||
       WrappedComponent.name ||
       'Component'})`;
 
     constructor(props: Props, context: Context) {
-      if (!context || !context.registeredElements) {
+      if (!context || !context.getRegisteredElements) {
         throw new Error(
           `It looks like you are trying to inject Stripe context outside of an Elements context.
 Please be sure the component that calls createSource or createToken is within an <Elements> component.`
@@ -83,7 +78,7 @@ Please be sure the component that calls createSource or createToken is within an
     };
     // Finds the element by the specified type. Throws if multiple Elements match.
     findElement = (specifiedType: string): ?ElementShape => {
-      const allElements = this.context.registeredElements || [];
+      const allElements = this.context.getRegisteredElements();
       const matchingElements =
         specifiedType === 'auto'
           ? allElements

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -26,7 +26,7 @@ describe('injectStripe()', () => {
         createSource,
         createToken,
       },
-      registeredElements: [elementMock],
+      getRegisteredElements: () => [elementMock],
     };
     WrappedComponent = () => <div />;
     WrappedComponent.displayName = 'WrappedComponent';
@@ -143,7 +143,7 @@ describe('injectStripe()', () => {
     const wrapper = shallow(<Injected />, {
       context: {
         ...context,
-        registeredElements: [],
+        getRegisteredElements: () => [],
       },
     });
 
@@ -210,7 +210,7 @@ describe('injectStripe()', () => {
     const wrapper = shallow(<Injected />, {
       context: {
         ...context,
-        registeredElements: [],
+        getRegisteredElements: () => [],
       },
     });
 
@@ -226,7 +226,7 @@ describe('injectStripe()', () => {
     const wrapper = shallow(<Injected />, {
       context: {
         ...context,
-        registeredElements: [
+        getRegisteredElements: () => [
           {
             type: 'card',
             element: {
@@ -255,7 +255,7 @@ describe('injectStripe()', () => {
     const wrapper = shallow(<Injected />, {
       context: {
         ...context,
-        registeredElements: [
+        getRegisteredElements: () => [
           {
             type: 'card',
             element: {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -13,6 +13,12 @@ import {
   PostalCodeElement,
 } from './index';
 
+class PureWrapper extends React.PureComponent {
+  render() {
+    return <div>{this.props.children}</div>;
+  }
+}
+
 describe('index', () => {
   let elementMock;
   let elementsMock;
@@ -70,6 +76,22 @@ describe('index', () => {
       </StripeProvider>
     );
     expect(app.text()).toMatch(/Hello world/);
+  });
+
+  it("shouldn't choke on pure components", () => {
+    const Checkout = WrappedCheckout('token');
+    const app = mount(
+      <StripeProvider apiKey="pk_test_xxx">
+        <Elements>
+          <PureWrapper>
+            <Checkout>
+              <CardElement />
+            </Checkout>
+          </PureWrapper>
+        </Elements>
+      </StripeProvider>
+    );
+    expect(() => app.find('form').simulate('submit')).not.toThrow();
   });
 
   describe('createToken', () => {


### PR DESCRIPTION
### Summary & motivation

Since React context is pulled rather than pushed to children, putting a pure
component between the `<Elements>` wrapper and its any individual `<Elements>`
would cause this error to be printed:

```
You did not specify the type of Source or Token to create. We could not infer which Element you want to use for this operation.
```

Basically, `registeredElements` was still the empty list, even if other
elements had been registered in the parent. We fixed this issue with these
three commits:


- **Add failing test for rendering pure components** (f551647)


- **Expose registeredElements through getter** (e357833)


- **Use getRegisteredElements instead of registeredElements** (c5f5cf5)


- **Update tests since context changed** (5a98a56)








### Testing & documentation

- [x] Fixed existing unit tests
- [x] Write test that would have caught this