### PR TITLE
fix: ie10 and below props access in constructors (#140)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,8 @@
 {
   "presets": ["react", "env"],
-  "plugins": ["transform-class-properties", "transform-object-rest-spread"]
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-rest-spread",
+    [ "transform-es2015-classes", { "loose": true } ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-jest": "^21.0.2",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,7 +646,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
-babel-plugin-transform-es2015-classes@^6.23.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:


### PR DESCRIPTION
### Summary & motivation

Fixes component constructors on **IE10 and below** by adding `transform-es2015-classes` in `.babelrc` (see #140 and [babel caveats](https://babeljs.io/docs/usage/caveats/#internet-explorer-classes-10-and-below-)).

### Testing & documentation

No changes to the react source code, only updating how it transpiles.
Tested on IE 9, 10, 11, Edge, Firefox (latest), Chrome (latest) and Safari (latest).
All tests still pass.
