### PR TITLE
fix split field tokenization issues with 1.3.0

### DIFF
--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -100,7 +100,7 @@ describe('Element', () => {
     });
   });
 
-  it.only("re-rendering with new props should still work if addElementsLoadListener hasn't fired yet", () => {
+  it("re-rendering with new props should still work if addElementsLoadListener hasn't fired yet", () => {
     // no-op function so that any registered listeners are never woken up
     context.addElementsLoadListener = () => {};
 

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -56,12 +56,19 @@ export default class Elements extends React.Component<Props, State> {
   getChildContext(): ChildContext {
     return {
       addElementsLoadListener: (fn: ElementsLoadListener) => {
+        // Return the existing elements instance if we already have one.
+        if (this._elements) {
+          fn(this._elements);
+          return;
+        }
         const {children, ...options} = this.props;
         if (this.context.tag === 'sync') {
-          fn(this.context.stripe.elements(options));
+          this._elements = this.context.stripe.elements(options);
+          fn(this._elements);
         } else {
           this.context.addStripeLoadListener((stripe: StripeShape) => {
-            fn(stripe.elements(options));
+            this._elements = stripe.elements(options);
+            fn(this._elements);
           });
         }
       },

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -1,0 +1,87 @@
+// @noflow
+import React from 'react';
+import {mount} from 'enzyme';
+
+import Elements from './Elements';
+
+describe('Elements', () => {
+  let stripeMock;
+
+  beforeEach(() => {
+    stripeMock = {
+      elements: jest
+        .fn(() => {
+          throw new Error(
+            'elements() should not be called twice in this test.'
+          );
+        })
+        .mockReturnValueOnce(true),
+      createToken: jest.fn(),
+      createSource: jest.fn(),
+    };
+  });
+
+  it('creates the context', () => {
+    const syncContext = {
+      tag: 'sync',
+      stripe: stripeMock,
+    };
+    const wrapper = mount(
+      <Elements>
+        <div />
+      </Elements>,
+      {context: syncContext}
+    );
+    const childContext = wrapper.node.getChildContext();
+    expect(Object.keys(childContext)).toEqual([
+      'addElementsLoadListener',
+      'registerElement',
+      'unregisterElement',
+      'getRegisteredElements',
+    ]);
+  });
+
+  it('with sync context: addElementsLoadListener returns the same elements instance ', () => {
+    const syncContext = {
+      tag: 'sync',
+      stripe: stripeMock,
+    };
+    const wrapper = mount(
+      <Elements>
+        <div />
+      </Elements>,
+      {context: syncContext}
+    );
+    const childContext = wrapper.node.getChildContext();
+
+    const mockCallback = jest.fn();
+    childContext.addElementsLoadListener(mockCallback);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenLastCalledWith(true);
+    childContext.addElementsLoadListener(mockCallback);
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+    expect(mockCallback).toHaveBeenCalledWith(true);
+  });
+
+  it('with async context: addElementsLoadListener returns the same elements instance ', () => {
+    const asyncContext = {
+      tag: 'async',
+      addStripeLoadListener: jest.fn(callback => callback(stripeMock)),
+    };
+    const wrapper = mount(
+      <Elements>
+        <div />
+      </Elements>,
+      {context: asyncContext}
+    );
+    const childContext = wrapper.node.getChildContext();
+
+    const mockCallback = jest.fn();
+    childContext.addElementsLoadListener(mockCallback);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback).toHaveBeenLastCalledWith(true);
+    childContext.addElementsLoadListener(mockCallback);
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+    expect(mockCallback).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -90,7 +90,7 @@ export default class Provider extends React.Component<Props> {
           "Please load Stripe.js (https://js.stripe.com/v3/) on this page to use react-stripe-elements. If Stripe.js isn't available yet (it's loading asynchronously, or you're using server-side rendering), see https://github.com/stripe/react-stripe-elements#TODO"
         );
       } else {
-        const {apiKey, children, ...options} = this.props;
+        const {apiKey, children, stripe, ...options} = this.props;
         this._meta = {
           tag: 'sync',
           stripe: getOrCreateStripe(apiKey, options),


### PR DESCRIPTION
### Summary & motivation

This PR address the issues mentioned in #146 

It stops accidentally including `stripe: undefined` in the stripe creation options which lead to a warning.

It fixes that we created new elements instances in `addElementsLoadListener ` instead of reusing the existing one, which resulted in split fields not working properly.

### Testing & documentation

I added unit tests that failed before the change and pass after.