### PR TITLE
Lint against skipped / focused tests

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -33,3 +33,5 @@ rules:
   no-unused-vars:
     - 2
     - ignoreRestSiblings: true
+  jest/no-disabled-tests: 2
+  jest/no-focused-tests: 2


### PR DESCRIPTION
### Summary & motivation

We accidentally committed `it.only` because we didn't have these settings
enabled.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests..." -->

ESLint only change → covered by CI.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->