### PR TITLE
Avoid race condition in async sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,14 @@ class App extends React.Component {
     this.state = {stripe: null};
   }
   componentDidMount() {
-    document.querySelector('#stripe-js').addEventListener('load', () => {
-      // Create Stripe instance once Stripe.js loads
+    if (window.Stripe) {
       this.setState({stripe: window.Stripe('pk_test_12345')});
-    });
+    } else {
+      document.querySelector('#stripe-js').addEventListener('load', () => {
+        // Create Stripe instance once Stripe.js loads
+        this.setState({stripe: window.Stripe('pk_test_12345')});
+      });
+    }
   }
   render() {
     // this.state.stripe will either be null or a Stripe instance
@@ -368,6 +372,12 @@ a Stripe instance. React will re-render `<InjectedCheckoutForm>` when
 You can find a working demo of this strategy in [async.js](demo/async/async.js).
 If you run the demo locally, you can view it at <http://localhost:8080/async/>.
 
+For alternatives to calling `setState`in `componentDidMount`, consider using a
+`setTimeout()`, moving the `if/else` statement to the `constructor`, or
+dynamically injecting a script tag in `componentDidMount`. For more
+information, see [stripe/react-stripe-elements][issue-154].
+
+[issue-154]: https://github.com/stripe/react-stripe-elements/issues/154
 
 
 ### Server-side rendering (SSR)


### PR DESCRIPTION
r? @michelle

### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Fixes #154.

There are three solutions we can go with here:

1. check in `constructor`
2. check in `componentDidMount`
3. check in `componentDidMount` with a `setTimeout`

We've chosen to do the second, because

- It avoids the original race.
- It avoids recommending `setTimeout` as the default.
- It runs in `componentDidMount`, which is where browser-dependent code should
  live.

The drawbacks are

- It violates the "no `setState` in `componentDidMount`" idiom of React.
- It delays the time to first paint.

The "no `setState`" rule is fine; people who care will have ESLint complaint
that they're doing something weird. They can then make the decision to use this
solution or another.

For the others, it avoids the race with the simplest code.