### PR TITLE
Fix broken API review link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Feature request or idea? Consider opening an [API review](.github/API_REVIEW.md)!
+Feature request or idea? Consider opening an [API review](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md)!
 
 ### Summary
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 <!-- Delete this section if this change involves no API changes. -->
 
-Copy [this template](.github/API_REVIEW.md) **or** link to an API review issue.
+Copy [this template](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md) **or** link to an API review issue.
 
 
 ### Testing & documentation


### PR DESCRIPTION
### Summary & motivation

The links to the API review document were broken.

They're absolute links now, which is important because they need to make sense
from both `tree/master/.github/ISSUE_TEMPLATE.md` and also `/issues/<number>`.