### PR TITLE
Allow setting of mount container id attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ These components accept all `options` that can be passed into `elements.create(t
 
 ```js
 type ElementProps = {
+  id?: string,
   className?: string,
   elementRef?: (StripeElement) => void,
 

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -121,7 +121,13 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
     };
 
     render() {
-      return <div id={this.props.id || undefined} className={this.props.className} ref={this.handleRef} />;
+      return (
+        <div
+          id={this.props.id || undefined}
+          className={this.props.className}
+          ref={this.handleRef}
+        />
+      );
     }
   };
 

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -5,6 +5,7 @@ import shallowEqual from '../utils/shallowEqual';
 import {type ElementContext, elementContextTypes} from './Elements';
 
 type Props = {
+  id: string,
   className: string,
   elementRef: Function,
   onChange: Function,
@@ -17,6 +18,7 @@ const noop = () => {};
 
 const _extractOptions = (props: Props): Object => {
   const {
+    id,
     className,
     elementRef,
     onChange,
@@ -31,6 +33,7 @@ const _extractOptions = (props: Props): Object => {
 const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
   class extends React.Component<Props> {
     static propTypes = {
+      id: PropTypes.string,
       className: PropTypes.string,
       elementRef: PropTypes.func,
       onChange: PropTypes.func,
@@ -39,6 +42,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
       onReady: PropTypes.func,
     };
     static defaultProps = {
+      id: '',
       className: '',
       elementRef: noop,
       onChange: noop,
@@ -67,7 +71,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
 
         this._setupEventListeners(element);
 
-        element.mount(this._ref);
+        element.mount(this.props.id ? `#${this.props.id}` : this._ref);
         if (hocOptions.sourceType) {
           this.context.registerElement(hocOptions.sourceType, element);
         }
@@ -117,7 +121,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
     };
 
     render() {
-      return <div className={this.props.className} ref={this.handleRef} />;
+      return <div id={this.props.id || undefined} className={this.props.className} ref={this.handleRef} />;
     }
   };
 

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -5,8 +5,8 @@ import shallowEqual from '../utils/shallowEqual';
 import {type ElementContext, elementContextTypes} from './Elements';
 
 type Props = {
-  id: string,
-  className: string,
+  id?: string,
+  className?: string,
   elementRef: Function,
   onChange: Function,
   onBlur: Function,
@@ -42,8 +42,8 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
       onReady: PropTypes.func,
     };
     static defaultProps = {
-      id: '',
-      className: '',
+      id: undefined,
+      className: undefined,
       elementRef: noop,
       onChange: noop,
       onBlur: noop,
@@ -71,7 +71,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
 
         this._setupEventListeners(element);
 
-        element.mount(this.props.id ? `#${this.props.id}` : this._ref);
+        element.mount(this._ref);
         if (hocOptions.sourceType) {
           this.context.registerElement(hocOptions.sourceType, element);
         }
@@ -123,7 +123,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
     render() {
       return (
         <div
-          id={this.props.id || undefined}
+          id={this.props.id}
           className={this.props.className}
           ref={this.handleRef}
         />

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -34,7 +34,7 @@ describe('Element', () => {
     const CardElement = Element('card', {sourceType: 'card'});
     const element = shallow(<CardElement id={id} />, {context});
     expect(element.find('#my-id').length).toBe(1);
-  })
+  });
 
   it('should pass className to the DOM element', () => {
     const className = 'my-class';

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -29,6 +29,13 @@ describe('Element', () => {
     };
   });
 
+  it('should pass id to the DOM element', () => {
+    const id = 'my-id';
+    const CardElement = Element('card', {sourceType: 'card'});
+    const element = shallow(<CardElement id={id} />, {context});
+    expect(element.find('#my-id').length).toBe(1);
+  })
+
   it('should pass className to the DOM element', () => {
     const className = 'my-class';
     const CardElement = Element('card', {sourceType: 'card'});


### PR DESCRIPTION
### Summary & motivation

Allow `id` prop on `<*Element />` component. This becomes an id selector on the mount container. Allows adjacent labels to reference the original element correctly.

### API review

See #177 .

### Testing & documentation

Added unit test to check that `id` prop is present on resulting div. I just added the prop to the docs without any explanation. I think it is obvious seeing as it is alongside `className`.
