### PR TITLE
Also allow id prop for PaymentRequestButtonElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ The props for the `PaymentRequestButtonElement` are:
 ```js
 type PaymentRequestButtonProps = {
   paymentRequest: StripePaymentRequest,
+  id?: string,
   className?: string,
   elementRef?: (StripeElement) => void,
 

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -5,7 +5,8 @@ import shallowEqual from '../utils/shallowEqual';
 import {type ElementContext, elementContextTypes} from './Elements';
 
 type Props = {
-  className: string,
+  id?: string,
+  className?: string,
   elementRef: Function,
   onBlur: Function,
   onClick: Function,
@@ -22,6 +23,7 @@ const noop = () => {};
 
 const _extractOptions = (props: Props): Object => {
   const {
+    id,
     className,
     elementRef,
     onBlur,
@@ -36,6 +38,7 @@ const _extractOptions = (props: Props): Object => {
 
 class PaymentRequestButtonElement extends React.Component<Props> {
   static propTypes = {
+    id: PropTypes.string,
     className: PropTypes.string,
     elementRef: PropTypes.func,
     onBlur: PropTypes.func,
@@ -49,7 +52,8 @@ class PaymentRequestButtonElement extends React.Component<Props> {
     }).isRequired,
   };
   static defaultProps = {
-    className: '',
+    id: undefined,
+    className: undefined,
     elementRef: noop,
     onBlur: noop,
     onClick: noop,
@@ -113,7 +117,13 @@ class PaymentRequestButtonElement extends React.Component<Props> {
   };
 
   render() {
-    return <div className={this.props.className} ref={this.handleRef} />;
+    return (
+      <div
+        id={this.props.id}
+        className={this.props.className}
+        ref={this.handleRef}
+      />
+    );
   }
 }
 

--- a/src/components/PaymentRequestButtonElement.test.js
+++ b/src/components/PaymentRequestButtonElement.test.js
@@ -35,6 +35,18 @@ describe('PaymentRequestButtonElement', () => {
     };
   });
 
+  it('should pass the id to the DOM element', () => {
+    const id = 'my-id';
+    const element = shallow(
+      <PaymentRequestButtonElement
+        id={id}
+        paymentRequest={paymentRequestMock}
+      />,
+      {context}
+    );
+    expect(element.find(`#${id}`)).toBeTruthy();
+  });
+
   it('should pass the className to the DOM element', () => {
     const className = 'my-class';
     const element = shallow(


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

This is pretty much the exact same diff as from #178.

We just forgot to apply it to the PaymentRequestButtonElement, which is
~basically the same as Element (it just has some extra Payment Request-specific
stuff, which is why it's separate).


### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

Unit tests & flow.