### PR TITLE
Deprecate and undocument elementRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ goes into more detail on the various customization options for Elements (e.g. st
   - [`<*Element>` components](#element-components)
     - [Available components](#available-components)
     - [Props shape](#props-shape-2)
+    - [Using `onReady`](#using-onready)
   - [`injectStripe` HOC](#injectstripe-hoc)
     - [Example](#example)
 - [Troubleshooting](#troubleshooting)
@@ -512,14 +513,13 @@ These components accept all `options` that can be passed into `elements.create(t
 type ElementProps = {
   id?: string,
   className?: string,
-  elementRef?: (StripeElement) => void,
 
   // For full documentation on the events and payloads below, see:
   // https://stripe.com/docs/elements/reference#element-on
   onBlur?: () => void,
   onChange?: (changeObject: Object) => void,
   onFocus?: () => void,
-  onReady?: () => void,
+  onReady?: (StripeElement) => void,
 };
 ```
 
@@ -530,14 +530,46 @@ type PaymentRequestButtonProps = {
   paymentRequest: StripePaymentRequest,
   id?: string,
   className?: string,
-  elementRef?: (StripeElement) => void,
 
   onBlur?: () => void,
   onClick?: () => void,
   onFocus?: () => void,
-  onReady?: () => void,
+  onReady?: (StripeElement) => void,
 };
 ```
+
+#### Using `onReady`
+
+Note that the `onReady` callback gives you access to the underlying [Element]
+created with Stripe.js. You can use this to get access to all the underlying
+methods that a Stripe Element supports.
+
+For example, you can use `onReady` to force your element to focus:
+
+```js
+// CardSection.js
+import React from 'react';
+import {CardElement} from 'react-stripe-elements';
+
+class CardSection extends React.Component {
+  render = () => {
+    return (
+      <label>
+        Card details
+        <CardElement
+          onReady={(el) => el.focus()}
+        />
+      </label>
+    );
+  };
+};
+
+export default CardSection;
+```
+
+(Note that this functionality is new as of react-stripe-elements v1.6.0.)
+
+[Element]: https://stripe.com/docs/stripe-js/reference#other-methods
 
 ### `injectStripe` HOC
 

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -7,7 +7,7 @@ import {type ElementContext, elementContextTypes} from './Elements';
 type Props = {
   id?: string,
   className?: string,
-  elementRef: Function,
+  elementRef?: Function,
   onChange: Function,
   onBlur: Function,
   onFocus: Function,
@@ -44,7 +44,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
     static defaultProps = {
       id: undefined,
       className: undefined,
-      elementRef: noop,
+      elementRef: undefined,
       onChange: noop,
       onBlur: noop,
       onFocus: noop,
@@ -104,8 +104,15 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
 
     _setupEventListeners(element: ElementShape) {
       element.on('ready', () => {
-        this.props.elementRef(this._element);
-        this.props.onReady();
+        if (this.props.elementRef) {
+          if (window.console && window.console.warn) {
+            console.warn(
+              "'elementRef()' is deprecated and will be removed in a future version of react-stripe-elements. Please use 'onReady()' instead."
+            );
+          }
+          this.props.elementRef(this._element);
+        }
+        this.props.onReady(this._element);
       });
 
       element.on('change', change => {

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -7,6 +7,7 @@ import {type ElementContext, elementContextTypes} from './Elements';
 type Props = {
   id?: string,
   className?: string,
+  // DEPRECATED; remove in 2.0.0+
   elementRef?: Function,
   onChange: Function,
   onBlur: Function,

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -83,7 +83,7 @@ describe('Element', () => {
 
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
     expect(elementRefMock).toHaveBeenCalledWith(elementMock);
-    expect(onReadyMock.mock.calls).toHaveLength(1);
+    expect(onReadyMock).toHaveBeenCalledWith(elementMock);
     expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
 
     global.console.warn = originalConsoleWarn;

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -83,7 +83,7 @@ describe('Element', () => {
 
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
     expect(elementRefMock).toHaveBeenCalledWith(elementMock);
-    expect(onReadyMock).toHaveBeenCalled();
+    expect(onReadyMock.mock.calls).toHaveLength(1);
     expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
 
     global.console.warn = originalConsoleWarn;

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -72,6 +72,11 @@ describe('Element', () => {
     const CardElement = Element('card', {sourceType: 'card'});
     const onReadyMock = jest.fn();
     const elementRefMock = jest.fn();
+
+    const originalConsoleWarn = global.console.warn;
+    const mockConsoleWarn = jest.fn();
+    global.console.warn = mockConsoleWarn;
+
     mount(<CardElement onReady={onReadyMock} elementRef={elementRefMock} />, {
       context,
     });
@@ -79,6 +84,9 @@ describe('Element', () => {
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
     expect(elementRefMock).toHaveBeenCalledWith(elementMock);
     expect(onReadyMock).toHaveBeenCalled();
+    expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
+
+    global.console.warn = originalConsoleWarn;
   });
 
   it('should update the Element when props change', () => {

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -7,7 +7,7 @@ import {type ElementContext, elementContextTypes} from './Elements';
 type Props = {
   id?: string,
   className?: string,
-  elementRef: Function,
+  elementRef?: Function,
   onBlur: Function,
   onClick: Function,
   onFocus: Function,
@@ -54,7 +54,7 @@ class PaymentRequestButtonElement extends React.Component<Props> {
   static defaultProps = {
     id: undefined,
     className: undefined,
-    elementRef: noop,
+    elementRef: undefined,
     onBlur: noop,
     onClick: noop,
     onFocus: noop,
@@ -79,7 +79,14 @@ class PaymentRequestButtonElement extends React.Component<Props> {
         ...this._options,
       });
       this._element.on('ready', () => {
-        this.props.elementRef(this._element);
+        if (this.props.elementRef) {
+          if (window.console && window.console.warn) {
+            console.warn(
+              "'elementRef()' is deprecated and will be removed in a future version of react-stripe-elements. Please use 'onReady()' instead."
+            );
+          }
+          this.props.elementRef(this._element);
+        }
         this.props.onReady();
       });
       this._element.on('focus', (...args) => this.props.onFocus(...args));

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -88,7 +88,7 @@ class PaymentRequestButtonElement extends React.Component<Props> {
           }
           this.props.elementRef(this._element);
         }
-        this.props.onReady();
+        this.props.onReady(this._element);
       });
       this._element.on('focus', (...args) => this.props.onFocus(...args));
       this._element.on('click', (...args) => this.props.onClick(...args));

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -7,6 +7,7 @@ import {type ElementContext, elementContextTypes} from './Elements';
 type Props = {
   id?: string,
   className?: string,
+  // DEPRECATED; remove in 2.0.0+
   elementRef?: Function,
   onBlur: Function,
   onClick: Function,

--- a/src/components/PaymentRequestButtonElement.test.js
+++ b/src/components/PaymentRequestButtonElement.test.js
@@ -62,6 +62,11 @@ describe('PaymentRequestButtonElement', () => {
   it('should call onReady and elementRef', () => {
     const onReadyMock = jest.fn();
     const elementRefMock = jest.fn();
+
+    const originalConsoleWarn = global.console.warn;
+    const mockConsoleWarn = jest.fn();
+    global.console.warn = mockConsoleWarn;
+
     mount(
       <PaymentRequestButtonElement
         onReady={onReadyMock}
@@ -74,6 +79,9 @@ describe('PaymentRequestButtonElement', () => {
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
     expect(onReadyMock).toHaveBeenCalled();
     expect(elementRefMock).toHaveBeenCalledWith(elementMock);
+    expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
+
+    global.console.warn = originalConsoleWarn;
   });
 
   it('should not register the Element', () => {

--- a/src/components/PaymentRequestButtonElement.test.js
+++ b/src/components/PaymentRequestButtonElement.test.js
@@ -77,7 +77,7 @@ describe('PaymentRequestButtonElement', () => {
     );
 
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
-    expect(onReadyMock).toHaveBeenCalled();
+    expect(onReadyMock.mock.calls).toHaveLength(1);
     expect(elementRefMock).toHaveBeenCalledWith(elementMock);
     expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
 

--- a/src/components/PaymentRequestButtonElement.test.js
+++ b/src/components/PaymentRequestButtonElement.test.js
@@ -77,7 +77,7 @@ describe('PaymentRequestButtonElement', () => {
     );
 
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
-    expect(onReadyMock.mock.calls).toHaveLength(1);
+    expect(onReadyMock).toHaveBeenCalledWith(elementMock);
     expect(elementRefMock).toHaveBeenCalledWith(elementMock);
     expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
 


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

The `elementRef` and the `onReady` callback are sort of redundant.
They both fire when `element.on(``'``ready``'``, …)` fires. Here's the source code:

    element.on('ready', () => {
      this.props.elementRef(this._element);
      this.props.onReady();
    });

I propose that we

- keep `elementRef` around
- undocument it (it's already minimally documented; not even used in the quickstart)
- change the `onReady` callback signature to accept the underlying `StripeElement` object.


### API review

<!-- Delete this section if this change involves no API changes. -->

The API review for this change was done internally at Stripe.
See `2018-02-27 — Deprecate elementRef in RSE`.


### Testing & documentation

The unit tests ensure that we log the deprecation warning.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->