### PR TITLE
super() is required if using constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Initialize `this.state.stripe` to `null` in the `constructor`, then update it in
 ```js
 class App extends React.Component {
   constructor() {
+    super();
     this.state = {stripe: null};
   }
   componentDidMount() {

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ load in `componentDidMount`; we can use `window.Stripe` directly.
 ```js
 class App extends React.Component {
   constructor() {
+    super();
     this.state = {stripe: null};
   }
   componentDidMount() {


### PR DESCRIPTION
Babel throws this error if you use constructor without super in a react component.: this' is not allowed before super(). Also I am pretty sure super() is required in any es6 class that extends another class.


### Summary & motivation

Code will not compile without super in react constructor.
