### PR TITLE
Deprecate optional source type in createSource

### DIFF
--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -152,6 +152,13 @@ Please be sure the component that calls createSource or createToken is within an
       if (options && typeof options === 'object') {
         const {type, ...rest} = options; // eslint-disable-line no-unused-vars
         const specifiedType = typeof type === 'string' ? type : 'auto';
+
+        if (specifiedType === 'auto' && window.console && window.console.warn) {
+          console.warn(
+            'Source type will be required in future versions of react-stripe-elements. Please pass in a valid source type when calling createSource().'
+          );
+        }
+
         const element = this.findElement(specifiedType);
         if (element) {
           return stripe.createSource(element, rest);

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -153,21 +153,23 @@ Please be sure the component that calls createSource or createToken is within an
         const {type, ...rest} = options; // eslint-disable-line no-unused-vars
         const specifiedType = typeof type === 'string' ? type : 'auto';
 
-        if (specifiedType === 'auto' && window.console && window.console.warn) {
-          console.warn(
-            'Source type will be required in future versions of react-stripe-elements. Please pass in a valid source type when calling createSource().'
-          );
-        }
-
         const element = this.findElement(specifiedType);
         if (element) {
+          if (
+            specifiedType === 'auto' &&
+            window.console &&
+            window.console.warn
+          ) {
+            console.warn(
+              "Inferred Source type of 'card' for createSource(). This behavior will be deprecated in a future version. Please pass the Source type to createSource() explicitly."
+            );
+          }
           return stripe.createSource(element, rest);
         } else if (specifiedType !== 'auto') {
           return stripe.createSource(options);
         } else {
           throw new Error(
-            `You did not specify the type of Source to create.
-          We also could not find any Elements in the current context.`
+            'You did not specify the type of Source to create. We also could not find any Elements in the current context.'
           );
         }
       } else {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

When calling `createSource`, we will soon require passing in the `type` parameter. As this is a breaking change, we will apply this in a new major version. This PR posts a deprecation notice in the current major version.

### API review

<!-- Delete this section if this change involves no API changes. -->

API review conducted internally.


### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Tested manually in the demo by calling `createSource` without `type`, with `type`, and with an invalid `type`. The result was as expected: the first test showed the warning, the second worked successfully, the third threw an error for invalid request.
