### PR TITLE
Require source type in createSource, update internal Element registration logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ form components in the `Elements` tree. The [Higher-Order Component][hoc]
 pattern in React can be unfamiliar to those who've never seen it before, so
 consider reading up before continuing. The `injectStripe` HOC provides the
 `this.props.stripe` property that manages your `Elements` groups. You can call
-`this.props.stripe.createToken` within a component that has been injected to
-submit payment data to Stripe.
+`this.props.stripe.createToken` or `this.props.stripe.createSource` within a
+component that has been injected to submit payment data to Stripe.
 
 [hoc]: https://facebook.github.io/react/docs/higher-order-components.html
 
@@ -189,7 +189,13 @@ class CheckoutForm extends React.Component {
     });
 
     // However, this line of code will do the same thing:
+    //
     // this.props.stripe.createToken({type: 'card', name: 'Jenny Rosen'});
+
+    // You can also use createSource to create Sources. See our Sources
+    // documentation for more: https://stripe.com/docs/stripe-js/reference#stripe-create-source
+    //
+    // this.props.stripe.createSource({type: 'card', name: 'Jenny Rosen'});
   }
 
   render() {
@@ -583,7 +589,9 @@ function injectStripe(
   }
 ): ReactClass;
 ```
-Components that need to initiate Source or Token creations (e.g. a checkout form component) can access `stripe.createToken` via props of any component returned by the `injectStripe` HOC factory.
+Components that need to initiate Source or Token creations (e.g. a checkout
+form component) can access `stripe.createToken` or `stripe.createSource` via
+props of any component returned by the `injectStripe` HOC factory.
 
 If the `withRef` option is set to `true`, the wrapped component instance will be available with the `getWrappedInstance()` method of the wrapper component. This feature can not be used if the wrapped component is a stateless function component.
 
@@ -601,6 +609,7 @@ type FactoryProps = {
   | null
   | {
     createToken: (tokenParameters: {type?: string}) => Promise<{token?: Object, error?: Object}>,
+    createSource: (sourceParameters: {type?: string}) => Promise<{source?: Object, error?: Object}>,
     // and other functions available on the `stripe` object,
     // as officially documented here: https://stripe.com/docs/elements/reference#the-stripe-object
   },

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -31,7 +31,10 @@ const _extractOptions = (props: Props): Object => {
   return options;
 };
 
-const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
+const Element = (
+  type: string,
+  hocOptions: {impliedTokenType?: string, impliedSourceType?: string} = {}
+) =>
   class extends React.Component<Props> {
     static propTypes = {
       id: PropTypes.string,
@@ -73,11 +76,18 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
         this._setupEventListeners(element);
 
         element.mount(this._ref);
-        if (hocOptions.sourceType) {
-          this.context.registerElement(hocOptions.sourceType, element);
+
+        // Register Element for automatic token / source creation
+        if (hocOptions.impliedTokenType || hocOptions.impliedSourceType) {
+          this.context.registerElement(
+            element,
+            hocOptions.impliedTokenType,
+            hocOptions.impliedSourceType
+          );
         }
       });
     }
+
     componentWillReceiveProps(nextProps: Props) {
       const options = _extractOptions(nextProps);
       if (
@@ -90,6 +100,7 @@ const Element = (type: string, hocOptions: {sourceType?: string} = {}) =>
         }
       }
     }
+
     componentWillUnmount() {
       if (this._element) {
         const element = this._element;

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -31,24 +31,37 @@ describe('Element', () => {
 
   it('should pass id to the DOM element', () => {
     const id = 'my-id';
-    const CardElement = Element('card', {sourceType: 'card'});
+    const CardElement = Element('card', {
+      impliedTokenType: 'card',
+      impliedSourceType: 'card',
+    });
     const element = shallow(<CardElement id={id} />, {context});
     expect(element.find('#my-id').length).toBe(1);
   });
 
   it('should pass className to the DOM element', () => {
     const className = 'my-class';
-    const CardElement = Element('card', {sourceType: 'card'});
+    const CardElement = Element('card', {
+      impliedTokenType: 'card',
+      impliedSourceType: 'card',
+    });
     const element = shallow(<CardElement className={className} />, {context});
     expect(element.first().hasClass(className)).toBeTruthy();
   });
 
-  it('should call the right hooks for a source Element', () => {
-    const SourceElement = Element('source', {sourceType: 'foobar'});
-    const element = mount(<SourceElement onChange={jest.fn()} />, {context});
+  it('should call the right hooks for a registered Element', () => {
+    const TestElement = Element('test', {
+      impliedTokenType: 'foo',
+      impliedSourceType: 'bar',
+    });
+    const element = mount(<TestElement onChange={jest.fn()} />, {context});
 
     expect(context.registerElement).toHaveBeenCalledTimes(1);
-    expect(context.registerElement).toHaveBeenCalledWith('foobar', elementMock);
+    expect(context.registerElement).toHaveBeenCalledWith(
+      elementMock,
+      'foo',
+      'bar'
+    );
 
     element.unmount();
     expect(elementMock.destroy).toHaveBeenCalledTimes(1);
@@ -56,9 +69,9 @@ describe('Element', () => {
     expect(context.unregisterElement).toHaveBeenCalledWith(elementMock);
   });
 
-  it('should call the right hooks for a non-source Element', () => {
-    const SourceElement = Element('source');
-    const element = mount(<SourceElement onChange={jest.fn()} />, {context});
+  it('should call the right hooks for a non-registered Element', () => {
+    const TestElement = Element('test');
+    const element = mount(<TestElement onChange={jest.fn()} />, {context});
 
     expect(context.registerElement).toHaveBeenCalledTimes(0);
 
@@ -69,7 +82,10 @@ describe('Element', () => {
   });
 
   it('should call onReady and elementRef', () => {
-    const CardElement = Element('card', {sourceType: 'card'});
+    const CardElement = Element('card', {
+      impliedTokenType: 'card',
+      impliedSourceType: 'card',
+    });
     const onReadyMock = jest.fn();
     const elementRefMock = jest.fn();
 
@@ -95,11 +111,13 @@ describe('Element', () => {
         fontSize: '16px',
       },
     };
-    const SourceElement = Element('source', {sourceType: 'foobar'});
-    const element = mount(
-      <SourceElement onChange={jest.fn()} style={style} />,
-      {context}
-    );
+    const TestElement = Element('test', {
+      impliedTokenType: 'foo',
+      impliedSourceType: 'bar',
+    });
+    const element = mount(<TestElement onChange={jest.fn()} style={style} />, {
+      context,
+    });
 
     expect(elementMock.update).toHaveBeenCalledTimes(0);
     element.setProps({style, onChange: jest.fn()});
@@ -120,7 +138,10 @@ describe('Element', () => {
     context.addElementsLoadListener = () => {};
 
     const placeholder = 'hello';
-    const CardElement = Element('card', {sourceType: 'card'});
+    const CardElement = Element('card', {
+      impliedTokenType: 'card',
+      impliedSourceType: 'card',
+    });
     const element = shallow(<CardElement placeholder={placeholder} />, {
       context,
     });

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -3,7 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {type ProviderContext, providerContextTypes} from './Provider';
 
-export type ElementsList = Array<{type: string, element: ElementShape}>;
+export type ElementsList = Array<{
+  element: ElementShape,
+  impliedTokenType?: string,
+  impliedSourceType?: string,
+}>;
 export type ElementsLoadListener = ElementsShape => void;
 
 type Props = {
@@ -24,7 +28,11 @@ export const injectContextTypes = {
 
 export type ElementContext = {
   addElementsLoadListener: ElementsLoadListener => void,
-  registerElement: (type: string, element: ElementShape) => void,
+  registerElement: (
+    element: ElementShape,
+    impliedTokenType: ?string,
+    impliedSourceType: ?string
+  ) => void,
   unregisterElement: (element: ElementShape) => void,
 };
 
@@ -45,6 +53,7 @@ export default class Elements extends React.Component<Props, State> {
   static defaultProps = {
     children: null,
   };
+
   constructor(props: Props, context: ProviderContext) {
     super(props, context);
 
@@ -81,13 +90,25 @@ export default class Elements extends React.Component<Props, State> {
       getRegisteredElements: () => this.state.registeredElements,
     };
   }
+
   props: Props;
   context: ProviderContext;
   _elements: ElementsShape;
 
-  handleRegisterElement = (type: string, element: Object) => {
+  handleRegisterElement = (
+    element: Object,
+    impliedTokenType: ?string,
+    impliedSourceType: ?string
+  ) => {
     this.setState(prevState => ({
-      registeredElements: [...prevState.registeredElements, {type, element}],
+      registeredElements: [
+        ...prevState.registeredElements,
+        {
+          element,
+          ...(impliedTokenType ? {impliedTokenType} : {}),
+          ...(impliedSourceType ? {impliedSourceType} : {}),
+        },
+      ],
     }));
   };
 

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -101,7 +101,9 @@ Please be sure the component that calls createSource or createToken is within an
       const matchingElements =
         specifiedType === 'auto'
           ? allElements
-          : allElements.filter(({type}) => type === specifiedType);
+          : allElements.filter(
+              ({impliedTokenType}) => impliedTokenType === specifiedType
+            );
 
       if (matchingElements.length === 1) {
         return matchingElements[0].element;

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -95,15 +95,19 @@ Please be sure the component that calls createSource or createToken is within an
         createSource: this.wrappedCreateSource(stripe),
       };
     }
-    // Finds the element by the specified type. Throws if multiple Elements match.
-    findElement = (specifiedType: string): ?ElementShape => {
+
+    // Finds an Element by the specified type, if one exists.
+    // Throws if multiple Elements match.
+    findElement = (
+      filterBy: 'impliedTokenType' | 'impliedSourceType',
+      specifiedType: string
+    ): ?ElementShape => {
       const allElements = this.context.getRegisteredElements();
+      const filteredElements = allElements.filter(e => e[filterBy]);
       const matchingElements =
         specifiedType === 'auto'
-          ? allElements
-          : allElements.filter(
-              ({impliedTokenType}) => impliedTokenType === specifiedType
-            );
+          ? filteredElements
+          : filteredElements.filter(e => e[filterBy] === specifiedType);
 
       if (matchingElements.length === 1) {
         return matchingElements[0].element;
@@ -116,9 +120,14 @@ Please be sure the component that calls createSource or createToken is within an
         return null;
       }
     };
-    // Require that exactly one Element is found.
-    requireElement = (specifiedType: string): ElementShape => {
-      const element = this.findElement(specifiedType);
+
+    // Require that exactly one Element is found for the specified type.
+    // Throws if no Element is found.
+    requireElement = (
+      filterBy: 'impliedTokenType' | 'impliedSourceType',
+      specifiedType: string
+    ): ElementShape => {
+      const element = this.findElement(filterBy, specifiedType);
       if (element) {
         return element;
       } else {
@@ -129,57 +138,68 @@ Please be sure the component that calls createSource or createToken is within an
       }
     };
 
-    // createToken has a bit of an unusual method signature for legacy reasons
-    // -- we're allowed to pass in the token type OR the element as the first parameter,
-    // so we need to check if we're passing in a string as the first parameter and
-    // just pass through the options if that's the case.
+    // Wraps createToken in order to infer the Element that is being tokenized.
     wrappedCreateToken = (stripe: StripeShape) => (
-      typeOrOptions: mixed = {},
+      tokenTypeOrOptions: mixed = {},
       options: mixed = {}
     ) => {
-      if (typeOrOptions && typeof typeOrOptions === 'object') {
-        const {type, ...rest} = typeOrOptions;
-        const specifiedType = typeof type === 'string' ? type : 'auto';
-        const element = this.requireElement(specifiedType);
+      if (tokenTypeOrOptions && typeof tokenTypeOrOptions === 'object') {
+        // First argument is options; infer the Element and tokenize
+        const opts = tokenTypeOrOptions;
+        const {type: tokenType, ...rest} = opts;
+        const specifiedType =
+          typeof tokenType === 'string' ? tokenType : 'auto';
+        // Since only options were passed in, a corresponding Element must exist
+        // for the tokenization to succeed -- thus we call requireElement.
+        const element = this.requireElement('impliedTokenType', specifiedType);
         return stripe.createToken(element, rest);
-      } else if (typeof typeOrOptions === 'string') {
-        return stripe.createToken(typeOrOptions, options);
+      } else if (typeof tokenTypeOrOptions === 'string') {
+        // First argument is token type; tokenize with token type and options
+        const tokenType = tokenTypeOrOptions;
+        return stripe.createToken(tokenType, options);
       } else {
+        // If a bad value was passed in for options, throw an error.
         throw new Error(
-          `Invalid options passed to createToken. Expected an object, got ${typeof typeOrOptions}.`
+          `Invalid options passed to createToken. Expected an object, got ${typeof tokenTypeOrOptions}.`
         );
       }
     };
+
+    // Wraps createSource in order to infer the Element that is being used for
+    // source creation.
     wrappedCreateSource = (stripe: StripeShape) => (options: mixed = {}) => {
       if (options && typeof options === 'object') {
-        const {type, ...rest} = options; // eslint-disable-line no-unused-vars
-        const specifiedType = typeof type === 'string' ? type : 'auto';
+        const {type: sourceType, ...rest} = options;
+        const specifiedType =
+          typeof sourceType === 'string' ? sourceType : 'auto';
+        const element = this.findElement('impliedSourceType', specifiedType);
 
-        const element = this.findElement(specifiedType);
         if (element) {
-          if (
-            specifiedType === 'auto' &&
-            window.console &&
-            window.console.warn
-          ) {
-            console.warn(
-              "Inferred Source type of 'card' for createSource(). This behavior will be deprecated in a future version. Please pass the Source type to createSource() explicitly."
-            );
-          }
+          // If an Element exists for the source type, use that to create the
+          // corresponding source.
+          //
+          // NOTE: this prevents users from independently creating sources of
+          // type `foo` if an Element that can create `foo` sources exists in
+          // the current <Elements /> context.
           return stripe.createSource(element, rest);
         } else if (specifiedType !== 'auto') {
+          // If no Element exists for the source type, directly create a source.
           return stripe.createSource(options);
         } else {
+          // If no type was specified and no Element exists that can create
+          // source, throw an error.
           throw new Error(
             'You did not specify the type of Source to create. We also could not find any Elements in the current context.'
           );
         }
       } else {
+        // If a bad value was passed in for options, throw an error.
         throw new Error(
           `Invalid options passed to createSource. Expected an object, got ${typeof options}.`
         );
       }
     };
+
     render() {
       return (
         <WrappedComponent

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -169,11 +169,13 @@ Please be sure the component that calls createSource or createToken is within an
     // source creation.
     wrappedCreateSource = (stripe: StripeShape) => (options: mixed = {}) => {
       if (options && typeof options === 'object') {
-        const {type: sourceType, ...rest} = options;
-        const specifiedType =
-          typeof sourceType === 'string' ? sourceType : 'auto';
-        const element = this.findElement('impliedSourceType', specifiedType);
+        if (typeof options.type !== 'string') {
+          throw new Error(
+            `Invalid Source type passed to createSource. Expected string, got ${typeof options.type}.`
+          );
+        }
 
+        const element = this.findElement('impliedSourceType', options.type);
         if (element) {
           // If an Element exists for the source type, use that to create the
           // corresponding source.
@@ -181,16 +183,10 @@ Please be sure the component that calls createSource or createToken is within an
           // NOTE: this prevents users from independently creating sources of
           // type `foo` if an Element that can create `foo` sources exists in
           // the current <Elements /> context.
-          return stripe.createSource(element, rest);
-        } else if (specifiedType !== 'auto') {
+          return stripe.createSource(element, options);
+        } else {
           // If no Element exists for the source type, directly create a source.
           return stripe.createSource(options);
-        } else {
-          // If no type was specified and no Element exists that can create
-          // source, throw an error.
-          throw new Error(
-            'You did not specify the type of Source to create. We also could not find any Elements in the current context.'
-          );
         }
       } else {
         // If a bad value was passed in for options, throw an error.

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -159,12 +159,12 @@ describe('injectStripe()', () => {
       });
 
       const props = wrapper.props();
-      expect(() => props.stripe.createToken()).toThrow(
+      expect(props.stripe.createToken).toThrow(
         /We could not infer which Element you want to use for this operation./
       );
     });
 
-    it('props.stripe.createSource calls createSource with element and empty options when called with no arguments', () => {
+    it('props.stripe.createSource errors when called without a type', () => {
       const Injected = injectStripe(WrappedComponent);
 
       const wrapper = shallow(<Injected />, {
@@ -172,8 +172,21 @@ describe('injectStripe()', () => {
       });
 
       const props = wrapper.props();
-      props.stripe.createSource();
-      expect(createSource).toHaveBeenCalledWith(elementMock.element, {});
+      expect(props.stripe.createSource).toThrow(/Invalid Source type/);
+    });
+
+    it('props.stripe.createSource calls createSource with element and type when only type is passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createSource({type: 'card'});
+      expect(createSource).toHaveBeenCalledWith(elementMock.element, {
+        type: 'card',
+      });
     });
 
     it('props.stripe.createSource calls createSource with options', () => {
@@ -186,6 +199,7 @@ describe('injectStripe()', () => {
       const props = wrapper.props();
       props.stripe.createSource({type: 'card', foo: 'bar'});
       expect(createSource).toHaveBeenCalledWith(elementMock.element, {
+        type: 'card',
         foo: 'bar',
       });
     });
@@ -212,22 +226,6 @@ describe('injectStripe()', () => {
       const props = wrapper.props();
       expect(() => props.stripe.createSource(1)).toThrow(
         'Invalid options passed to createSource. Expected an object, got number.'
-      );
-    });
-
-    it('props.stripe.createSource throws when called without element/source-type and no elements are in the tree', () => {
-      const Injected = injectStripe(WrappedComponent);
-
-      const wrapper = shallow(<Injected />, {
-        context: {
-          ...context,
-          getRegisteredElements: () => [],
-        },
-      });
-
-      const props = wrapper.props();
-      expect(() => props.stripe.createSource()).toThrow(
-        /You did not specify the type of Source to create/
       );
     });
 
@@ -258,37 +256,6 @@ describe('injectStripe()', () => {
 
       const props = wrapper.props();
       expect(() => props.stripe.createSource({type: 'card'})).toThrow(
-        /We could not infer which Element you want to use for this operation/
-      );
-    });
-
-    it('props.stripe.createSource throws when called with no source type and tree has multiple elements', () => {
-      const Injected = injectStripe(WrappedComponent);
-
-      const wrapper = shallow(<Injected />, {
-        context: {
-          ...context,
-          getRegisteredElements: () => [
-            {
-              element: {
-                on: jest.fn(),
-              },
-              impliedTokenType: 'card',
-              impliedSourceType: 'card',
-            },
-            {
-              element: {
-                on: jest.fn(),
-              },
-              impliedTokenType: 'card',
-              impliedSourceType: 'card',
-            },
-          ],
-        },
-      });
-
-      const props = wrapper.props();
-      expect(() => props.stripe.createSource()).toThrow(
         /We could not infer which Element you want to use for this operation/
       );
     });

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -16,10 +16,11 @@ describe('injectStripe()', () => {
     createSource = jest.fn();
     createToken = jest.fn();
     elementMock = {
-      type: 'card',
       element: {
         on: jest.fn(),
       },
+      impliedTokenType: 'card',
+      impliedSourceType: 'card',
     };
     WrappedComponent = () => <div />;
     WrappedComponent.displayName = 'WrappedComponent';
@@ -238,16 +239,18 @@ describe('injectStripe()', () => {
           ...context,
           getRegisteredElements: () => [
             {
-              type: 'card',
               element: {
                 on: jest.fn(),
               },
+              impliedTokenType: 'card',
+              impliedSourceType: 'card',
             },
             {
-              type: 'card',
               element: {
                 on: jest.fn(),
               },
+              impliedTokenType: 'card',
+              impliedSourceType: 'card',
             },
           ],
         },
@@ -267,16 +270,18 @@ describe('injectStripe()', () => {
           ...context,
           getRegisteredElements: () => [
             {
-              type: 'card',
               element: {
                 on: jest.fn(),
               },
+              impliedTokenType: 'card',
+              impliedSourceType: 'card',
             },
             {
-              type: 'card',
               element: {
                 on: jest.fn(),
               },
+              impliedTokenType: 'card',
+              impliedSourceType: 'card',
             },
           ],
         },

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,14 @@ import Elements from './components/Elements';
 import Element from './components/Element';
 import PaymentRequestButtonElement from './components/PaymentRequestButtonElement';
 
-const CardElement = Element('card', {sourceType: 'card'});
-const CardNumberElement = Element('cardNumber', {sourceType: 'card'});
+const CardElement = Element('card', {
+  impliedTokenType: 'card',
+  impliedSourceType: 'card',
+});
+const CardNumberElement = Element('cardNumber', {
+  impliedTokenType: 'card',
+  impliedSourceType: 'card',
+});
 const CardExpiryElement = Element('cardExpiry');
 const CardCVCElement = Element('cardCvc');
 const PostalCodeElement = Element('postalCode');

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -161,24 +161,7 @@ describe('index', () => {
 
   describe('createSource', () => {
     it('should be called when set up properly', () => {
-      const Checkout = WrappedCheckout('source');
-      const app = mount(
-        <StripeProvider apiKey="pk_test_xxx">
-          <Elements>
-            <Checkout>
-              Hello world
-              <CardElement />
-            </Checkout>
-          </Elements>
-        </StripeProvider>
-      );
-      app.find('form').simulate('submit');
-      expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
-      expect(stripeMock.createSource).toHaveBeenCalledWith(elementMock, {});
-    });
-
-    it('should take additional parameters', () => {
-      const Checkout = WrappedCheckout('source', {owner: {name: 'Michelle'}});
+      const Checkout = WrappedCheckout('source', {type: 'card'});
       const app = mount(
         <StripeProvider apiKey="pk_test_xxx">
           <Elements>
@@ -192,7 +175,50 @@ describe('index', () => {
       app.find('form').simulate('submit');
       expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
       expect(stripeMock.createSource).toHaveBeenCalledWith(elementMock, {
+        type: 'card',
+      });
+    });
+
+    it('should take additional parameters', () => {
+      const Checkout = WrappedCheckout('source', {
+        type: 'card',
         owner: {name: 'Michelle'},
+      });
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>
+              Hello world
+              <CardElement />
+            </Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createSource).toHaveBeenCalledWith(elementMock, {
+        type: 'card',
+        owner: {name: 'Michelle'},
+      });
+    });
+
+    it('should be callable when no Element is found', () => {
+      const Checkout = WrappedCheckout('source', {
+        type: 'card',
+        token: 'tok_xxx',
+      });
+      const app = mount(
+        <StripeProvider apiKey="pk_test_xxx">
+          <Elements>
+            <Checkout>Hello world</Checkout>
+          </Elements>
+        </StripeProvider>
+      );
+      app.find('form').simulate('submit');
+      expect(stripeMock.createSource).toHaveBeenCalledTimes(1);
+      expect(stripeMock.createSource).toHaveBeenCalledWith({
+        type: 'card',
+        token: 'tok_xxx',
       });
     });
 
@@ -229,17 +255,20 @@ describe('index', () => {
 
   describe('errors', () => {
     describe('createSource', () => {
-      it('should throw when no Element found', () => {
+      it('should throw if no source type is specified', () => {
         const Checkout = WrappedCheckout('source');
         const app = mount(
           <StripeProvider apiKey="pk_test_xxx">
             <Elements>
-              <Checkout>Hello world</Checkout>
+              <Checkout>
+                Hello world
+                <CardElement />
+              </Checkout>
             </Elements>
           </StripeProvider>
         );
         expect(() => app.find('form').simulate('submit')).toThrowError(
-          /did not specify/
+          /Invalid Source type/
         );
       });
     });


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Updates `createSource` to always require the Source type. Also:

- Updates internal logic around how an Element registers its implied Token / Source type
- Updates the wrapper functions for `createToken` and `createSource` to be better documented
- Updates README to include examples of using `createSource`

This is a breaking change. We will publish `v2.0.0` along with a few other PRs that will follow.

This PR can be reviewed commit by commit.

### API review

Internal API review conducted to make Source type required in `createSource`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Updated existing tests, removed no longer relevant tests, added one new one. 
