### PR TITLE
Add IBAN and iDEAL Bank Elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 node_modules
 dist
 es
 lib
+*.log

--- a/README.md
+++ b/README.md
@@ -512,6 +512,8 @@ These components display the UI for Elements, and must be used within `StripePro
 - `CardCVCElement`
 - `PostalCodeElement`
 - `PaymentRequestButtonElement`
+- `IbanElement`
+- `IdealBankElement`
 
 #### Props shape
 
@@ -535,9 +537,10 @@ The props for the `PaymentRequestButtonElement` are:
 
 ```js
 type PaymentRequestButtonProps = {
-  paymentRequest: StripePaymentRequest,
   id?: string,
   className?: string,
+
+  paymentRequest: StripePaymentRequest,
 
   onBlur?: () => void,
   onClick?: () => void,

--- a/demo/async/index.html
+++ b/demo/async/index.html
@@ -1,105 +1,108 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>async demo | react-stripe-elements</title>
-    <style>
-* {
-  box-sizing: border-box;
-}
 
-body, html {
-  background-color: #f6f9fc;
-  font-size: 18px;
-  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
-}
+<head>
+  <title>async demo | react-stripe-elements</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
 
-h1 {
-  color: #32325d;
-  font-weight: 400;
-  line-height: 50px;
-  font-size: 40px;
-  margin: 20px 0;
-  padding: 0;
-}
+    body,
+    html {
+      background-color: #f6f9fc;
+      font-size: 18px;
+      font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    }
 
-.Checkout {
-  margin: 0 auto;
-  max-width: 800px;
-  box-sizing: border-box;
-  padding: 0 5px;
-}
+    h1 {
+      color: #32325d;
+      font-weight: 400;
+      line-height: 50px;
+      font-size: 40px;
+      margin: 20px 0;
+      padding: 0;
+    }
 
-label {
-  color: #6b7c93;
-  font-weight: 300;
-  letter-spacing: 0.025em;
-}
+    .Checkout {
+      margin: 0 auto;
+      max-width: 800px;
+      box-sizing: border-box;
+      padding: 0 5px;
+    }
 
-button {
-  white-space: nowrap;
-  border: 0;
-  outline: 0;
-  display: inline-block;
-  height: 40px;
-  line-height: 40px;
-  padding: 0 14px;
-  box-shadow: 0 4px 6px rgba(50, 50, 93, .11), 0 1px 3px rgba(0, 0, 0, .08);
-  color: #fff;
-  border-radius: 4px;
-  font-size: 15px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-  background-color: #6772e5;
-  text-decoration: none;
-  -webkit-transition: all 150ms ease;
-  transition: all 150ms ease;
-  margin-top: 10px;
-}
+    label {
+      color: #6b7c93;
+      font-weight: 300;
+      letter-spacing: 0.025em;
+    }
 
-form {
-  margin: 80px 0;
-}
+    button {
+      white-space: nowrap;
+      border: 0;
+      outline: 0;
+      display: inline-block;
+      height: 40px;
+      line-height: 40px;
+      padding: 0 14px;
+      box-shadow: 0 4px 6px rgba(50, 50, 93, .11), 0 1px 3px rgba(0, 0, 0, .08);
+      color: #fff;
+      border-radius: 4px;
+      font-size: 15px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+      background-color: #6772e5;
+      text-decoration: none;
+      -webkit-transition: all 150ms ease;
+      transition: all 150ms ease;
+      margin-top: 10px;
+    }
 
-button:hover {
-  color: #fff;
-  cursor: pointer;
-  background-color: #7795f8;
-  transform: translateY(-1px);
-  box-shadow: 0 7px 14px rgba(50, 50, 93, .10), 0 3px 6px rgba(0, 0, 0, .08);
-}
+    form {
+      margin: 80px 0;
+    }
 
-.StripeElement {
-  display: block;
-  margin: 10px 0 20px 0;
-  max-width: 500px;
-  padding: 10px 14px;
-  box-shadow: rgba(50, 50, 93, 0.14902) 0px 1px 3px, rgba(0, 0, 0, 0.0196078) 0px 1px 0px;
-  border-radius: 4px;
-  background: white;
-}
+    button:hover {
+      color: #fff;
+      cursor: pointer;
+      background-color: #7795f8;
+      transform: translateY(-1px);
+      box-shadow: 0 7px 14px rgba(50, 50, 93, .10), 0 3px 6px rgba(0, 0, 0, .08);
+    }
 
-.StripeElement--focus {
-  box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px, rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
-  -webkit-transition: all 150ms ease;
-  transition: all 150ms ease;
-}
+    .StripeElement {
+      display: block;
+      margin: 10px 0 20px 0;
+      max-width: 500px;
+      padding: 10px 14px;
+      box-shadow: rgba(50, 50, 93, 0.14902) 0px 1px 3px, rgba(0, 0, 0, 0.0196078) 0px 1px 0px;
+      border-radius: 4px;
+      background: white;
+    }
 
-button[disabled] {
-  opacity: 0.6;
-}
+    .StripeElement--focus {
+      box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px, rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
+      -webkit-transition: all 150ms ease;
+      transition: all 150ms ease;
+    }
 
-.StripeElement.loading {
-  height: 41.6px;
-  opacity: 0.6;
-}
+    button[disabled] {
+      opacity: 0.6;
+    }
 
-    </style>
-  </head>
-  <body>
-    <div class="App">
-    </div>
-    <script src="/async.js"></script>
-    <!-- NOTE: The Stripe.js script tag is manually injected in /async.js -->
-  </body>
+    .StripeElement.loading {
+      height: 41.6px;
+      opacity: 0.6;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="App">
+  </div>
+  <script src="/async.js"></script>
+  <!-- NOTE: The Stripe.js script tag is manually injected in /async.js -->
+</body>
+
 </html>

--- a/demo/demo/index.html
+++ b/demo/demo/index.html
@@ -1,101 +1,105 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>demo | react-stripe-elements</title>
-    <script src="https://js.stripe.com/v3/"></script>
-    <style>
-* {
-  box-sizing: border-box;
-}
 
-body, html {
-  background-color: #f6f9fc;
-  font-size: 18px;
-  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
-}
+<head>
+  <title>demo | react-stripe-elements</title>
+  <script src="https://js.stripe.com/v3/"></script>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
 
-h1 {
-  color: #32325d;
-  font-weight: 400;
-  line-height: 50px;
-  font-size: 40px;
-  margin: 20px 0;
-  padding: 0;
-}
+    body,
+    html {
+      background-color: #f6f9fc;
+      font-size: 18px;
+      font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    }
 
-.Checkout {
-  margin: 0 auto;
-  max-width: 800px;
-  box-sizing: border-box;
-  padding: 0 5px;
-}
+    h1 {
+      color: #32325d;
+      font-weight: 400;
+      line-height: 50px;
+      font-size: 40px;
+      margin: 20px 0;
+      padding: 0;
+    }
 
-label {
-  color: #6b7c93;
-  font-weight: 300;
-  letter-spacing: 0.025em;
-}
+    .Checkout {
+      margin: 0 auto;
+      max-width: 800px;
+      box-sizing: border-box;
+      padding: 0 5px;
+    }
 
-button {
-  white-space: nowrap;
-  border: 0;
-  outline: 0;
-  display: inline-block;
-  height: 40px;
-  line-height: 40px;
-  padding: 0 14px;
-  box-shadow: 0 4px 6px rgba(50, 50, 93, .11), 0 1px 3px rgba(0, 0, 0, .08);
-  color: #fff;
-  border-radius: 4px;
-  font-size: 15px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-  background-color: #6772e5;
-  text-decoration: none;
-  -webkit-transition: all 150ms ease;
-  transition: all 150ms ease;
-  margin-top: 10px;
-}
+    label {
+      color: #6b7c93;
+      font-weight: 300;
+      letter-spacing: 0.025em;
+    }
 
-form {
-  margin-bottom: 40px;
-  padding-bottom: 40px;
-  border-bottom: 3px solid #e6ebf1;
-}
+    button {
+      white-space: nowrap;
+      border: 0;
+      outline: 0;
+      display: inline-block;
+      height: 40px;
+      line-height: 40px;
+      padding: 0 14px;
+      box-shadow: 0 4px 6px rgba(50, 50, 93, .11), 0 1px 3px rgba(0, 0, 0, .08);
+      color: #fff;
+      border-radius: 4px;
+      font-size: 15px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+      background-color: #6772e5;
+      text-decoration: none;
+      -webkit-transition: all 150ms ease;
+      transition: all 150ms ease;
+      margin-top: 10px;
+    }
 
-button:hover {
-  color: #fff;
-  cursor: pointer;
-  background-color: #7795f8;
-  transform: translateY(-1px);
-  box-shadow: 0 7px 14px rgba(50, 50, 93, .10), 0 3px 6px rgba(0, 0, 0, .08);
-}
+    form {
+      margin-bottom: 40px;
+      padding-bottom: 40px;
+      border-bottom: 3px solid #e6ebf1;
+    }
 
-.StripeElement {
-  display: block;
-  margin: 10px 0 20px 0;
-  max-width: 500px;
-  padding: 10px 14px;
-  box-shadow: rgba(50, 50, 93, 0.14902) 0px 1px 3px, rgba(0, 0, 0, 0.0196078) 0px 1px 0px;
-  border-radius: 4px;
-  background: white;
-}
+    button:hover {
+      color: #fff;
+      cursor: pointer;
+      background-color: #7795f8;
+      transform: translateY(-1px);
+      box-shadow: 0 7px 14px rgba(50, 50, 93, .10), 0 3px 6px rgba(0, 0, 0, .08);
+    }
 
-.StripeElement--focus {
-  box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px, rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
-  -webkit-transition: all 150ms ease;
-  transition: all 150ms ease;
-}
+    .StripeElement {
+      display: block;
+      margin: 10px 0 20px 0;
+      max-width: 500px;
+      padding: 10px 14px;
+      box-shadow: rgba(50, 50, 93, 0.14902) 0px 1px 3px, rgba(0, 0, 0, 0.0196078) 0px 1px 0px;
+      border-radius: 4px;
+      background: white;
+    }
 
-.StripeElement.PaymentRequestButton {
-  padding: 0;
-}
-    </style>
-  </head>
-  <body>
-    <div class="App">
-    </div>
-    <script src="/demo.js"></script>
-  </body>
+    .StripeElement--focus {
+      box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px, rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
+      -webkit-transition: all 150ms ease;
+      transition: all 150ms ease;
+    }
+
+    .StripeElement.PaymentRequestButton {
+      padding: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="App">
+  </div>
+  <script src="/demo.js"></script>
+</body>
+
 </html>

--- a/demo/demo/index.html
+++ b/demo/demo/index.html
@@ -74,22 +74,33 @@
       box-shadow: 0 7px 14px rgba(50, 50, 93, .10), 0 3px 6px rgba(0, 0, 0, .08);
     }
 
+    input,
     .StripeElement {
       display: block;
       margin: 10px 0 20px 0;
       max-width: 500px;
       padding: 10px 14px;
+      font-size: 1em;
+      font-family: 'Source Code Pro', monospace;
       box-shadow: rgba(50, 50, 93, 0.14902) 0px 1px 3px, rgba(0, 0, 0, 0.0196078) 0px 1px 0px;
+      border: 0;
+      outline: 0;
       border-radius: 4px;
       background: white;
     }
 
+    input::placeholder {
+      color: #aab7c4;
+    }
+
+    input:focus,
     .StripeElement--focus {
       box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px, rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
       -webkit-transition: all 150ms ease;
       transition: all 150ms ease;
     }
 
+    .StripeElement.IdealBankElement,
     .StripeElement.PaymentRequestButton {
       padding: 0;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,18 @@ import Elements from './components/Elements';
 import Element from './components/Element';
 import PaymentRequestButtonElement from './components/PaymentRequestButtonElement';
 
+// Define Elements, and register their implied token / source types for
+// automatic token / source creation.
+
+// Card
 const CardElement = Element('card', {
   impliedTokenType: 'card',
   impliedSourceType: 'card',
 });
+
+// Split Fields
+// Note: we only register the CardNumberElement for split fields so that we have
+// a unique Element to infer when calling `wrappedCreateToken` or `wrappedCreateSource`.
 const CardNumberElement = Element('cardNumber', {
   impliedTokenType: 'card',
   impliedSourceType: 'card',
@@ -16,6 +24,15 @@ const CardNumberElement = Element('cardNumber', {
 const CardExpiryElement = Element('cardExpiry');
 const CardCVCElement = Element('cardCvc');
 const PostalCodeElement = Element('postalCode');
+
+// IBAN
+const IbanElement = Element('iban', {
+  impliedTokenType: 'bank_account',
+  impliedSourceType: 'sepa_debit',
+});
+
+// iDEAL Bank
+const IdealBankElement = Element('idealBank', {impliedSourceType: 'ideal'});
 
 export {
   StripeProvider,
@@ -27,4 +44,6 @@ export {
   CardCVCElement,
   PostalCodeElement,
   PaymentRequestButtonElement,
+  IbanElement,
+  IdealBankElement,
 };


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Adds support for the `iban` and `idealBank` Elements. 

Also updates README and demo to include them.

<img width="836" alt="screen shot 2018-05-31 at 1 47 33 pm" src="https://user-images.githubusercontent.com/31416034/40807466-3450a756-64d9-11e8-8b22-db5556d7c4e9.png">

### Testing & documentation

Added examples to the demo and made sure they worked. Our wrapping framework is general enough to allow addition of new Elements without adding Element-specific tests.
