### PR TITLE
Remove elementRef

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -7,8 +7,6 @@ import {type ElementContext, elementContextTypes} from './Elements';
 type Props = {
   id?: string,
   className?: string,
-  // DEPRECATED; remove in 2.0.0+
-  elementRef?: Function,
   onChange: Function,
   onBlur: Function,
   onFocus: Function,
@@ -18,16 +16,7 @@ type Props = {
 const noop = () => {};
 
 const _extractOptions = (props: Props): Object => {
-  const {
-    id,
-    className,
-    elementRef,
-    onChange,
-    onFocus,
-    onBlur,
-    onReady,
-    ...options
-  } = props;
+  const {id, className, onChange, onFocus, onBlur, onReady, ...options} = props;
   return options;
 };
 
@@ -39,7 +28,6 @@ const Element = (
     static propTypes = {
       id: PropTypes.string,
       className: PropTypes.string,
-      elementRef: PropTypes.func,
       onChange: PropTypes.func,
       onBlur: PropTypes.func,
       onFocus: PropTypes.func,
@@ -48,7 +36,6 @@ const Element = (
     static defaultProps = {
       id: undefined,
       className: undefined,
-      elementRef: undefined,
       onChange: noop,
       onBlur: noop,
       onFocus: noop,
@@ -116,14 +103,6 @@ const Element = (
 
     _setupEventListeners(element: ElementShape) {
       element.on('ready', () => {
-        if (this.props.elementRef) {
-          if (window.console && window.console.warn) {
-            console.warn(
-              "'elementRef()' is deprecated and will be removed in a future version of react-stripe-elements. Please use 'onReady()' instead."
-            );
-          }
-          this.props.elementRef(this._element);
-        }
         this.props.onReady(this._element);
       });
 

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -81,28 +81,19 @@ describe('Element', () => {
     expect(context.unregisterElement).toHaveBeenCalledWith(elementMock);
   });
 
-  it('should call onReady and elementRef', () => {
+  it('should call onReady', () => {
     const CardElement = Element('card', {
       impliedTokenType: 'card',
       impliedSourceType: 'card',
     });
     const onReadyMock = jest.fn();
-    const elementRefMock = jest.fn();
 
-    const originalConsoleWarn = global.console.warn;
-    const mockConsoleWarn = jest.fn();
-    global.console.warn = mockConsoleWarn;
-
-    mount(<CardElement onReady={onReadyMock} elementRef={elementRefMock} />, {
+    mount(<CardElement onReady={onReadyMock} />, {
       context,
     });
 
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
-    expect(elementRefMock).toHaveBeenCalledWith(elementMock);
     expect(onReadyMock).toHaveBeenCalledWith(elementMock);
-    expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
-
-    global.console.warn = originalConsoleWarn;
   });
 
   it('should update the Element when props change', () => {

--- a/src/components/PaymentRequestButtonElement.js
+++ b/src/components/PaymentRequestButtonElement.js
@@ -7,8 +7,6 @@ import {type ElementContext, elementContextTypes} from './Elements';
 type Props = {
   id?: string,
   className?: string,
-  // DEPRECATED; remove in 2.0.0+
-  elementRef?: Function,
   onBlur: Function,
   onClick: Function,
   onFocus: Function,
@@ -26,7 +24,6 @@ const _extractOptions = (props: Props): Object => {
   const {
     id,
     className,
-    elementRef,
     onBlur,
     onClick,
     onFocus,
@@ -41,7 +38,6 @@ class PaymentRequestButtonElement extends React.Component<Props> {
   static propTypes = {
     id: PropTypes.string,
     className: PropTypes.string,
-    elementRef: PropTypes.func,
     onBlur: PropTypes.func,
     onClick: PropTypes.func,
     onFocus: PropTypes.func,
@@ -55,7 +51,6 @@ class PaymentRequestButtonElement extends React.Component<Props> {
   static defaultProps = {
     id: undefined,
     className: undefined,
-    elementRef: undefined,
     onBlur: noop,
     onClick: noop,
     onFocus: noop,
@@ -80,14 +75,6 @@ class PaymentRequestButtonElement extends React.Component<Props> {
         ...this._options,
       });
       this._element.on('ready', () => {
-        if (this.props.elementRef) {
-          if (window.console && window.console.warn) {
-            console.warn(
-              "'elementRef()' is deprecated and will be removed in a future version of react-stripe-elements. Please use 'onReady()' instead."
-            );
-          }
-          this.props.elementRef(this._element);
-        }
         this.props.onReady(this._element);
       });
       this._element.on('focus', (...args) => this.props.onFocus(...args));

--- a/src/components/PaymentRequestButtonElement.test.js
+++ b/src/components/PaymentRequestButtonElement.test.js
@@ -59,18 +59,12 @@ describe('PaymentRequestButtonElement', () => {
     expect(element.first().hasClass(className)).toBeTruthy();
   });
 
-  it('should call onReady and elementRef', () => {
+  it('should call onReady', () => {
     const onReadyMock = jest.fn();
-    const elementRefMock = jest.fn();
-
-    const originalConsoleWarn = global.console.warn;
-    const mockConsoleWarn = jest.fn();
-    global.console.warn = mockConsoleWarn;
 
     mount(
       <PaymentRequestButtonElement
         onReady={onReadyMock}
-        elementRef={elementRefMock}
         paymentRequest={paymentRequestMock}
       />,
       {context}
@@ -78,10 +72,6 @@ describe('PaymentRequestButtonElement', () => {
 
     expect(elementMock.on.mock.calls[0][0]).toBe('ready');
     expect(onReadyMock).toHaveBeenCalledWith(elementMock);
-    expect(elementRefMock).toHaveBeenCalledWith(elementMock);
-    expect(mockConsoleWarn.mock.calls[0][0]).toMatch(/deprecated/);
-
-    global.console.warn = originalConsoleWarn;
   });
 
   it('should not register the Element', () => {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

`elementRef` was a function prop that could be passed to individual `<Element />` components, and would be called with a reference to the Element instance once it was ready. This was deprecated in https://github.com/stripe/react-stripe-elements/pull/181.

This PR removes support for `elementRef` altogether. This is a breaking change, and will be published as part of `v2.0.0`.

### Testing & documentation

Updated existing tests to no longer reference `elementRef`. The suggested alternative is using `onReady`, and that continues to work.
