### PR TITLE
Update prettier config, run on CSS and Markdown by default

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,9 +17,6 @@ rules:
   no-duplicate-imports: 2 # doesn't support flow imports.
   no-console: 0
   func-style: 2
-  arrow-parens:
-    - 2
-    - 'as-needed'
   consistent-return: 2
   prefer-arrow-callback:
     - 2

--- a/.github/API_REVIEW.md
+++ b/.github/API_REVIEW.md
@@ -24,46 +24,46 @@ possible to omit some of the sections below.
 ```md
 #### Summary
 
-> A brief of the new API, including a code sample.
-> Consider where this feature would fit into our documentation,
-> and what the updated documentation would look like.
+> A brief of the new API, including a code sample. Consider where this feature
+> would fit into our documentation, and what the updated documentation would
+> look like.
 
 <!-- TODO -->
 
 #### Motivation
 
-> Describe the problem you are trying to solve with this API change.
-> What does this API enable that was previously not possible?
+> Describe the problem you are trying to solve with this API change. What does
+> this API enable that was previously not possible?
 
 <!-- TODO -->
 
 #### Similar APIs
 
-> Is this new API similar to an existing Stripe API?
-> Are there similar APIs or prior art in other popular projects?
+> Is this new API similar to an existing Stripe API? Are there similar APIs or
+> prior art in other popular projects?
 
 <!-- TODO -->
 
 #### Alternatives
 
-> How else could we implement this feature?
-> Are there any existing workarounds that would offer the same functionality?
-> Why should we chose this implementation over another?
+> How else could we implement this feature? Are there any existing workarounds
+> that would offer the same functionality? Why should we chose this
+> implementation over another?
 
 <!-- TODO -->
 
 #### Scope
 
-> Which interfaces will this apply to? For example, is this specific
-> to one component, or does it affect all Element components?
-> Does this set a precedent for future interfaces we'll add?
+> Which interfaces will this apply to? For example, is this specific to one
+> component, or does it affect all Element components? Does this set a precedent
+> for future interfaces we'll add?
 
 <!-- TODO -->
 
 #### Risks
 
-> Are there any security implications (for example, XSS)?
-> What are some ways users might get confused or misuse this feature?
+> Are there any security implications (for example, XSS)? What are some ways
+> users might get confused or misuse this feature?
 
 <!-- TODO -->
 ```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
-Feature request or idea? Consider opening an [API review](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md)!
+Feature request or idea? Consider opening an
+[API review](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md)!
 
 <!--
 react-stripe-elements is a thin wrapper around Stripe.js and Stripe
@@ -11,15 +12,12 @@ come chat with us at #stripe on freenode. We're very proud of our level of
 service, and we're more than happy to help you out with your integration.
 -->
 
-
 ### Summary
 
 <!-- For bug reports, include detailed steps to reproduce or a minimal reproduction of the issue (You can even start from this JSFiddle: https://jsfiddle.net/g9rm5qkt/) -->
-
 
 ### Other information
 
 <!-- For visual issues, include screenshots! -->
 
 <!-- Is this specific to one browser, or does it happen in multiple browsers? -->
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,10 @@
 
 <!-- Delete this section if this change involves no API changes. -->
 
-Copy
-[this template](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md)
-**or** link to an API review issue.
+Copy [this template] **or** link to an API review issue.
+
+[this template]:
+  https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md
 
 ### Testing & documentation
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-
 ### Summary & motivation
 
 <!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
@@ -7,8 +6,9 @@
 
 <!-- Delete this section if this change involves no API changes. -->
 
-Copy [this template](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md) **or** link to an API review issue.
-
+Copy
+[this template](https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md)
+**or** link to an API review issue.
 
 ### Testing & documentation
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+es
+lib
+package.json

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,5 @@
 singleQuote: true
 trailingComma: es5
 bracketSpacing: false
-parser: flow
+arrowParens: always
+proseWrap: always

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -3,3 +3,4 @@ trailingComma: es5
 bracketSpacing: false
 arrowParens: always
 proseWrap: always
+parser: flow

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -3,4 +3,3 @@ trailingComma: es5
 bracketSpacing: false
 arrowParens: always
 proseWrap: always
-parser: flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 Thanks for contributing to react-stripe-elements!
 
-
 ## Issues
 
 `react-stripe-elements` is a thin wrapper around [Stripe.js] and [Stripe
@@ -16,7 +15,6 @@ service, and we're more than happy to help you out with your integration.
 
 If you've found a bug in `react-stripe-elements`, please [let us know][issue]!
 You may also want to check out our [issue template][issue-template].
-
 
 ## API review
 
@@ -38,7 +36,6 @@ Stripe, we believe that code review is for explaining and having a discussion
 around code. For those new to code review, we strongly recommend [this
 video][code-review] on "code review culture."
 
-
 ## Developing
 
 We use a number of automated checks:
@@ -52,13 +49,12 @@ We use a number of automated checks:
 - Prettier, for code formatting
   - `yarn run prettier`
 
-You might want to configure your editor to automatically run these checks.
-Not passing any of these checks will cause the CI build to fail.
-
+You might want to configure your editor to automatically run these checks. Not
+passing any of these checks will cause the CI build to fail.
 
 [code-review]: https://www.youtube.com/watch?v=PJjmw9TRB7s
 [api-review]: .github/API_REVIEW.md
-[Stripe.js]: https://stripe.com/docs/stripe.js
+[stripe.js]: https://stripe.com/docs/stripe.js
 [elements]: https://stripe.com/elements
 [issue]: https://github.com/stripe/react-stripe-elements/issues/new
 [issue-template]: .github/ISSUE_TEMPLATE.md

--- a/README.md
+++ b/README.md
@@ -5,15 +5,21 @@
 
 > React components for Stripe.js and Stripe Elements
 
-This project is a thin React wrapper around [Stripe.js](https://stripe.com/docs/stripe.js)
-and [Stripe Elements](https://stripe.com/docs/elements). It allows you to add Elements
-to any React app, and manages the state and lifecycle of Elements for you.
+This project is a thin React wrapper around
+[Stripe.js](https://stripe.com/docs/stripe.js) and
+[Stripe Elements](https://stripe.com/docs/elements). It allows you to add
+Elements to any React app, and manages the state and lifecycle of Elements for
+you.
 
-The [Stripe.js / Stripe Elements API reference](https://stripe.com/docs/elements/reference)
-goes into more detail on the various customization options for Elements (e.g. styles, fonts).
+The
+[Stripe.js / Stripe Elements API reference](https://stripe.com/docs/elements/reference)
+goes into more detail on the various customization options for Elements (e.g.
+styles, fonts).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 ## Table of Contents
 
 - [Demo](#demo)
@@ -66,8 +72,9 @@ yarn run demo
 
 Now go to <http://localhost:8080/> to try it out!
 
-> :warning: `PaymentRequestButtonElement` will not render unless the page is served over HTTPS.
-> To demo `PaymentRequestButtonElement`, you can tunnel over HTTPS to the local server using ngrok or a similar service.
+> :warning: `PaymentRequestButtonElement` will not render unless the page is
+> served over HTTPS. To demo `PaymentRequestButtonElement`, you can tunnel over
+> HTTPS to the local server using ngrok or a similar service.
 
 ![Screenshot of the demo running](demo/demo.png)
 
@@ -103,7 +110,8 @@ OR using UMD build (exports a global `ReactStripeElements` object);
 
 ### The Stripe context (`StripeProvider`)
 
-In order for your application to have access to [the Stripe object](https://stripe.com/docs/elements/reference#the-stripe-object),
+In order for your application to have access to
+[the Stripe object](https://stripe.com/docs/elements/reference#the-stripe-object),
 let's add `StripeProvider` to our root React App component:
 
 ```js
@@ -127,9 +135,10 @@ render(<App />, document.getElementById('root'));
 
 ### Element groups (`Elements`)
 
-Next, when you're building components for your checkout form, you'll want to wrap the `Elements` component around your `form`.
-This groups the set of Stripe Elements you're using together, so that we're able to pull data from groups of Elements when
-you're tokenizing.
+Next, when you're building components for your checkout form, you'll want to
+wrap the `Elements` component around your `form`. This groups the set of Stripe
+Elements you're using together, so that we're able to pull data from groups of
+Elements when you're tokenizing.
 
 ```js
 // MyStoreCheckout.js
@@ -165,7 +174,7 @@ component that has been injected to submit payment data to Stripe.
 
 > :warning: NOTE `injectStripe` cannot be used on the same element that renders
 > the `Elements` component; it must be used on the child component of
-> `Elements`. `injectStripe` *returns a wrapped component* that needs to sit
+> `Elements`. `injectStripe` _returns a wrapped component_ that needs to sit
 > under `<Elements>` but above any code where you'd like to access
 > `this.props.stripe`.
 
@@ -196,7 +205,7 @@ class CheckoutForm extends React.Component {
     // documentation for more: https://stripe.com/docs/stripe-js/reference#stripe-create-source
     //
     // this.props.stripe.createSource({type: 'card', name: 'Jenny Rosen'});
-  }
+  };
 
   render() {
     return (
@@ -214,7 +223,8 @@ export default injectStripe(CheckoutForm);
 
 ### Using individual `*Element` components
 
-Now, you can use individual `*Element` components, such as `CardElement`, to build your form.
+Now, you can use individual `*Element` components, such as `CardElement`, to
+build your form.
 
 ```js
 // CardSection.js
@@ -230,17 +240,23 @@ class CardSection extends React.Component {
       </label>
     );
   }
-};
+}
 
 export default CardSection;
 ```
 
 ### Using the `PaymentRequestButtonElement`
 
-The [Payment Request Button](https://stripe.com/docs/elements/payment-request-button) lets you collect payment and address information from your customers using Apple Pay and the Payment Request API.
+The
+[Payment Request Button](https://stripe.com/docs/elements/payment-request-button)
+lets you collect payment and address information from your customers using Apple
+Pay and the Payment Request API.
 
-To use the `PaymentRequestButtonElement` you need to first create a [`PaymentRequest` object](https://stripe.com/docs/stripe.js#the-payment-request-object).
-You can then conditionally render the `PaymentRequestButtonElement` based on the result of `paymentRequest.canMakePayment` and pass the `PaymentRequest` Object as a prop.
+To use the `PaymentRequestButtonElement` you need to first create a
+[`PaymentRequest` object](https://stripe.com/docs/stripe.js#the-payment-request-object).
+You can then conditionally render the `PaymentRequestButtonElement` based on the
+result of `paymentRequest.canMakePayment` and pass the `PaymentRequest` Object
+as a prop.
 
 ```js
 class PaymentRequestForm extends React.Component {
@@ -264,7 +280,7 @@ class PaymentRequestForm extends React.Component {
       complete('success');
     });
 
-    paymentRequest.canMakePayment().then(result => {
+    paymentRequest.canMakePayment().then((result) => {
       this.setState({canMakePayment: !!result});
     });
 
@@ -323,7 +339,6 @@ Loading Stripe.js asynchronously can speed up your initial page load, especially
 if you don't show the payment form until the user interacts with your
 application in some way.
 
-
 ```html
 <html>
 <head>
@@ -341,7 +356,6 @@ application in some way.
 
 Initialize `this.state.stripe` to `null` in the `constructor`, then update it in
 `componentDidMount` when the script tag has loaded.
-
 
 ```js
 class App extends React.Component {
@@ -382,11 +396,10 @@ If you run the demo locally, you can view it at <http://localhost:8080/async/>.
 
 For alternatives to calling `setState`in `componentDidMount`, consider using a
 `setTimeout()`, moving the `if/else` statement to the `constructor`, or
-dynamically injecting a script tag in `componentDidMount`. For more
-information, see [stripe/react-stripe-elements][issue-154].
+dynamically injecting a script tag in `componentDidMount`. For more information,
+see [stripe/react-stripe-elements][issue-154].
 
 [issue-154]: https://github.com/stripe/react-stripe-elements/issues/154
-
 
 ### Server-side rendering (SSR)
 
@@ -452,24 +465,31 @@ class App extends React.Component {
 }
 ```
 
-As long as `<App />` is provided a non-`null` `stripe` prop,
-`this.props.stripe` will always be available within your `InjectedCheckoutForm`.
-
+As long as `<App />` is provided a non-`null` `stripe` prop, `this.props.stripe`
+will always be available within your `InjectedCheckoutForm`.
 
 ## Component reference
 
 ### `<StripeProvider>`
 
-All applications using `react-stripe-elements` must use the `<StripeProvider>`  component, which sets up the Stripe context for a component tree.
-`react-stripe-elements` uses the provider pattern (which is also adopted by tools like [`react-redux`](https://github.com/reactjs/react-redux) and [`react-intl`](https://github.com/yahoo/react-intl)) to scope a Stripe context to a tree of components.
+All applications using `react-stripe-elements` must use the `<StripeProvider>`
+component, which sets up the Stripe context for a component tree.
+`react-stripe-elements` uses the provider pattern (which is also adopted by
+tools like [`react-redux`](https://github.com/reactjs/react-redux) and
+[`react-intl`](https://github.com/yahoo/react-intl)) to scope a Stripe context
+to a tree of components.
 
-This allows configuration like your API key to be provided at the root of a component tree. This context is then made available to the `<Elements>` component and individual `<*Element>` components that we provide.
+This allows configuration like your API key to be provided at the root of a
+component tree. This context is then made available to the `<Elements>`
+component and individual `<*Element>` components that we provide.
 
-An integration usually wraps the `<StripeProvider>` around the application’s root component. This way, your entire application has the configured Stripe context.
+An integration usually wraps the `<StripeProvider>` around the application’s
+root component. This way, your entire application has the configured Stripe
+context.
 
 #### Props shape
 
-There are two *distinct* props shapes you can pass to `<StripeProvider>`.
+There are two _distinct_ props shapes you can pass to `<StripeProvider>`.
 
 ```js
 type StripeProviderProps =
@@ -477,18 +497,21 @@ type StripeProviderProps =
   | { stripe: StripeObject | null };
 ```
 
-See [Advanced integrations](#advanced-integrations) for more
-information on when to use each.
+See [Advanced integrations](#advanced-integrations) for more information on when
+to use each.
 
-The `...` above represents that this component accepts props for any option that can be passed into `Stripe(apiKey, options)`.
+The `...` above represents that this component accepts props for any option that
+can be passed into `Stripe(apiKey, options)`.
 
 ### `<Elements>`
 
-The `Elements` component wraps groups of Elements that belong together. In most cases, you want to wrap this around your checkout form.
+The `Elements` component wraps groups of Elements that belong together. In most
+cases, you want to wrap this around your checkout form.
 
 #### Props shape
 
-This component accepts all `options` that can be passed into `stripe.elements(options)` as props.
+This component accepts all `options` that can be passed into
+`stripe.elements(options)` as props.
 
 ```js
 type ElementsProps = {
@@ -500,7 +523,8 @@ type ElementsProps = {
 
 ### `<*Element>` components
 
-These components display the UI for Elements, and must be used within `StripeProvider` and `Elements`.
+These components display the UI for Elements, and must be used within
+`StripeProvider` and `Elements`.
 
 #### Available components
 
@@ -517,7 +541,8 @@ These components display the UI for Elements, and must be used within `StripePro
 
 #### Props shape
 
-These components accept all `options` that can be passed into `elements.create(type, options)` as props.
+These components accept all `options` that can be passed into
+`elements.create(type, options)` as props.
 
 ```js
 type ElementProps = {
@@ -567,20 +592,18 @@ class CardSection extends React.Component {
     return (
       <label>
         Card details
-        <CardElement
-          onReady={(el) => el.focus()}
-        />
+        <CardElement onReady={(el) => el.focus()} />
       </label>
     );
   };
-};
+}
 
 export default CardSection;
 ```
 
 (Note that this functionality is new as of react-stripe-elements v1.6.0.)
 
-[Element]: https://stripe.com/docs/stripe-js/reference#other-methods
+[element]: https://stripe.com/docs/stripe-js/reference#other-methods
 
 ### `injectStripe` HOC
 
@@ -592,11 +615,15 @@ function injectStripe(
   }
 ): ReactClass;
 ```
-Components that need to initiate Source or Token creations (e.g. a checkout
-form component) can access `stripe.createToken` or `stripe.createSource` via
-props of any component returned by the `injectStripe` HOC factory.
 
-If the `withRef` option is set to `true`, the wrapped component instance will be available with the `getWrappedInstance()` method of the wrapper component. This feature can not be used if the wrapped component is a stateless function component.
+Components that need to initiate Source or Token creations (e.g. a checkout form
+component) can access `stripe.createToken` or `stripe.createSource` via props of
+any component returned by the `injectStripe` HOC factory.
+
+If the `withRef` option is set to `true`, the wrapped component instance will be
+available with the `getWrappedInstance()` method of the wrapper component. This
+feature can not be used if the wrapped component is a stateless function
+component.
 
 #### Example
 
@@ -608,51 +635,77 @@ The following props will be available to this component:
 
 ```js
 type FactoryProps = {
-  stripe:
-  | null
-  | {
-    createToken: (tokenParameters: {type?: string}) => Promise<{token?: Object, error?: Object}>,
-    createSource: (sourceParameters: {type?: string}) => Promise<{source?: Object, error?: Object}>,
+  stripe: null | {
+    createToken: (tokenParameters: {type?: string}) => Promise<{
+      token?: Object,
+      error?: Object,
+    }>,
+    createSource: (sourceParameters: {type?: string}) => Promise<{
+      source?: Object,
+      error?: Object,
+    }>,
     // and other functions available on the `stripe` object,
     // as officially documented here: https://stripe.com/docs/elements/reference#the-stripe-object
   },
 };
 ```
 
-`stripe` is only `null` when using one of the [Advanced
-integrations](#advanced-integrations) mentioned above.
+`stripe` is only `null` when using one of the
+[Advanced integrations](#advanced-integrations) mentioned above.
 
 ## Troubleshooting
 
-`react-stripe-elements` may not work properly when used with components that implement `shouldComponentUpdate`. `react-stripe-elements` relies heavily on React's `context` feature and `shouldComponentUpdate` does not provide a way to take context updates into account when deciding whether to allow a re-render. These components can block context updates from reaching `react-stripe-element` components in the tree.
+`react-stripe-elements` may not work properly when used with components that
+implement `shouldComponentUpdate`. `react-stripe-elements` relies heavily on
+React's `context` feature and `shouldComponentUpdate` does not provide a way to
+take context updates into account when deciding whether to allow a re-render.
+These components can block context updates from reaching `react-stripe-element`
+components in the tree.
 
-For example, when using `react-stripe-elements` together with [`react-redux`](https://github.com/reactjs/react-redux) doing the following will not work:
+For example, when using `react-stripe-elements` together with
+[`react-redux`](https://github.com/reactjs/react-redux) doing the following will
+not work:
 
 ```js
 const Component = connect()(injectStripe(_Component));
 ```
 
-In this case, the context updates originating from the `StripeProvider` are not reaching the components wrapped inside the `connect` function. Therefore, `react-stripe-elements` components deeper in the tree break. The reason is that the `connect` function of `react-redux` [implements `shouldComponentUpdate`](https://github.com/reactjs/react-redux/blob/master/docs/troubleshooting.md#my-views-arent-updating-when-something-changes-outside-of-redux) and blocks re-renders that are triggered by context changes outside of the connected component.
+In this case, the context updates originating from the `StripeProvider` are not
+reaching the components wrapped inside the `connect` function. Therefore,
+`react-stripe-elements` components deeper in the tree break. The reason is that
+the `connect` function of `react-redux`
+[implements `shouldComponentUpdate`](https://github.com/reactjs/react-redux/blob/master/docs/troubleshooting.md#my-views-arent-updating-when-something-changes-outside-of-redux)
+and blocks re-renders that are triggered by context changes outside of the
+connected component.
 
 There are two ways to prevent this issue:
 
-1. Change the order of the functions to have `injectStripe` be the outermost one:
+1.  Change the order of the functions to have `injectStripe` be the outermost
+    one:
 
     ```js
     const Component = injectStripe(connect()(_CardForm));
     ```
 
-  This works, because `injectStripe` does not implement `shouldComponentUpdate` itself, so context updates originating from the `redux` `Provider` will still reach all components.
+This works, because `injectStripe` does not implement `shouldComponentUpdate`
+itself, so context updates originating from the `redux` `Provider` will still
+reach all components.
 
-2. You can use the [`pure: false`][pure-false] option for redux-connect:
+2.  You can use the [`pure: false`][pure-false] option for redux-connect:
 
     ```js
-    const Component = connect(mapStateToProps, mapDispatchToProps, mergeProps, {
-      pure: false,
-    })(injectStripe(_CardForm));
+    const Component = connect(
+      mapStateToProps,
+      mapDispatchToProps,
+      mergeProps,
+      {
+        pure: false,
+      }
+    )(injectStripe(_CardForm));
     ```
 
-[pure-false]: https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options
+[pure-false]:
+  https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ The
 goes into more detail on the various customization options for Elements (e.g.
 styles, fonts).
 
+<!-- prettier-ignore-start -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 ## Table of Contents
 
 - [Demo](#demo)
@@ -51,6 +50,7 @@ styles, fonts).
 - [Development](#development)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- prettier-ignore-end -->
 
 ## Demo
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "flow": "flow",
     "build": "yarn run lint && yarn run flow && yarn run build:commonjs && yarn run build:es && yarn run build:umd && yarn run build:umd:min",
     "clean": "rimraf lib dist es",
-    "prettier": "prettier src/**/*.js demo/**/*.js --write",
-    "prettier-list-different": "prettier src/**/*.js demo/**/*.js --list-different",
+    "prettier": "prettier **/*.js **/*.css **/*.md --write",
+    "prettier-list-different": "prettier **/*.js **/*.css **/*.md --list-different",
     "prepublish": "yarn run clean && yarn run build",
     "demo": "webpack-dev-server --content-base dist",
     "doctoc": "doctoc README.md"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -43,10 +43,10 @@ describe('index', () => {
   });
 
   const WrappedCheckout = (type, additionalOptions) => {
-    const MyCheckout = props => {
+    const MyCheckout = (props) => {
       return (
         <form
-          onSubmit={ev => {
+          onSubmit={(ev) => {
             ev.preventDefault();
             if (type === 'token') {
               props.stripe.createToken(additionalOptions);
@@ -133,9 +133,9 @@ describe('index', () => {
     });
 
     it('should be callable for other token types', () => {
-      const Checkout = injectStripe(props => (
+      const Checkout = injectStripe((props) => (
         <form
-          onSubmit={ev => {
+          onSubmit={(ev) => {
             ev.preventDefault();
             props.stripe.createToken('bank_account', {some: 'data'});
           }}
@@ -223,9 +223,9 @@ describe('index', () => {
     });
 
     it('should be callable for other source types', () => {
-      const Checkout = injectStripe(props => (
+      const Checkout = injectStripe((props) => (
         <form
-          onSubmit={ev => {
+          onSubmit={(ev) => {
             ev.preventDefault();
             props.stripe.createSource({
               type: 'three_d_secure',
@@ -277,7 +277,7 @@ describe('index', () => {
       it('should throw when not in Elements', () => {
         // Prevent the expected console.error from react to keep the test output clean
         const originalConsoleError = global.console.error;
-        global.console.error = msg => {
+        global.console.error = (msg) => {
           if (
             !msg.startsWith(
               'Warning: Failed context type: The context `getRegisteredElements` is marked as required'


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

Updates our prettier config to run on CSS and Markdown files by default (officially supported by Prettier.) Note that while HTML support exists, it is still in beta, so we choose not to include it here.

Also runs the new config on all our files.

### Testing & documentation

I ran prettier on the codebase, and checked that it worked as expected.
