### PR TITLE
Add mandate notification method to IBAN demo, fix prettier command

### DIFF
--- a/demo/async/async.js
+++ b/demo/async/async.js
@@ -14,7 +14,7 @@ import {
 const handleBlur = () => {
   console.log('[blur]');
 };
-const handleChange = change => {
+const handleChange = (change) => {
   console.log('[change]', change);
 };
 const handleFocus = () => {
@@ -41,12 +41,12 @@ const CARD_ELEMENT_OPTIONS = {
 };
 
 class _CardForm extends React.Component<InjectedProps> {
-  handleSubmit = ev => {
+  handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
       this.props.stripe
         .createToken()
-        .then(payload => console.log('[token]', payload));
+        .then((payload) => console.log('[token]', payload));
     } else {
       console.log('Form submitted before Stripe.js loaded.');
     }

--- a/demo/demo/index.js
+++ b/demo/demo/index.js
@@ -22,7 +22,7 @@ import {
 const handleBlur = () => {
   console.log('[blur]');
 };
-const handleChange = change => {
+const handleChange = (change) => {
   console.log('[change]', change);
 };
 const handleClick = () => {
@@ -56,12 +56,12 @@ const createOptions = (fontSize: string, padding: ?string) => {
 };
 
 class _CardForm extends React.Component<InjectedProps & {fontSize: string}> {
-  handleSubmit = ev => {
+  handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
       this.props.stripe
         .createToken()
-        .then(payload => console.log('[token]', payload));
+        .then((payload) => console.log('[token]', payload));
     } else {
       console.log("Stripe.js hasn't loaded yet.");
     }
@@ -87,12 +87,12 @@ class _CardForm extends React.Component<InjectedProps & {fontSize: string}> {
 const CardForm = injectStripe(_CardForm);
 
 class _SplitForm extends React.Component<InjectedProps & {fontSize: string}> {
-  handleSubmit = ev => {
+  handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
       this.props.stripe
         .createToken()
-        .then(payload => console.log('[token]', payload));
+        .then((payload) => console.log('[token]', payload));
     } else {
       console.log("Stripe.js hasn't loaded yet.");
     }
@@ -172,7 +172,7 @@ class _PaymentRequestForm extends React.Component<
       complete('success');
     });
 
-    paymentRequest.canMakePayment().then(result => {
+    paymentRequest.canMakePayment().then((result) => {
       this.setState({canMakePayment: !!result});
     });
 
@@ -210,7 +210,7 @@ class _PaymentRequestForm extends React.Component<
 const PaymentRequestForm = injectStripe(_PaymentRequestForm);
 
 class _IbanForm extends React.Component<InjectedProps & {fontSize: string}> {
-  handleSubmit = ev => {
+  handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
       this.props.stripe
@@ -221,8 +221,11 @@ class _IbanForm extends React.Component<InjectedProps & {fontSize: string}> {
             name: ev.target.name.value,
             email: ev.target.email.value,
           },
+          mandate: {
+            notification_method: 'email',
+          },
         })
-        .then(payload => console.log('[source]', payload));
+        .then((payload) => console.log('[source]', payload));
     } else {
       console.log("Stripe.js hasn't loaded yet.");
     }
@@ -264,7 +267,7 @@ const IbanForm = injectStripe(_IbanForm);
 class _IdealBankForm extends React.Component<
   InjectedProps & {fontSize: string}
 > {
-  handleSubmit = ev => {
+  handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
       this.props.stripe
@@ -279,7 +282,7 @@ class _IdealBankForm extends React.Component<
             return_url: 'https://example.com',
           },
         })
-        .then(payload => console.log('[source]', payload));
+        .then((payload) => console.log('[source]', payload));
     } else {
       console.log("Stripe.js hasn't loaded yet.");
     }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "flow": "flow",
     "build": "yarn run lint && yarn run flow && yarn run build:commonjs && yarn run build:es && yarn run build:umd && yarn run build:umd:min",
     "clean": "rimraf lib dist es",
-    "prettier": "prettier **/*.js **/*.css **/*.md --write",
-    "prettier-list-different": "prettier **/*.js **/*.css **/*.md --list-different",
+    "prettier": "prettier './**/*.js' './**/*.css' './**/*.md' --write",
+    "prettier-list-different": "prettier './**/*.js' './**/*.css' './**/*.md' --list-different",
     "prepublish": "yarn run clean && yarn run build",
     "demo": "webpack-dev-server --content-base dist",
     "doctoc": "doctoc README.md"

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -106,7 +106,7 @@ const Element = (
         this.props.onReady(this._element);
       });
 
-      element.on('change', change => {
+      element.on('change', (change) => {
         this.props.onChange(change);
       });
 

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -23,7 +23,7 @@ describe('Element', () => {
       create: jest.fn().mockReturnValue(elementMock),
     };
     context = {
-      addElementsLoadListener: fn => fn(elementsMock),
+      addElementsLoadListener: (fn) => fn(elementsMock),
       registerElement: jest.fn(),
       unregisterElement: jest.fn(),
     };

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -8,7 +8,7 @@ export type ElementsList = Array<{
   impliedTokenType?: string,
   impliedSourceType?: string,
 }>;
-export type ElementsLoadListener = ElementsShape => void;
+export type ElementsLoadListener = (ElementsShape) => void;
 
 type Props = {
   children?: any,
@@ -27,7 +27,7 @@ export const injectContextTypes = {
 };
 
 export type ElementContext = {
-  addElementsLoadListener: ElementsLoadListener => void,
+  addElementsLoadListener: (ElementsLoadListener) => void,
   registerElement: (
     element: ElementShape,
     impliedTokenType: ?string,
@@ -100,7 +100,7 @@ export default class Elements extends React.Component<Props, State> {
     impliedTokenType: ?string,
     impliedSourceType: ?string
   ) => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       registeredElements: [
         ...prevState.registeredElements,
         {
@@ -113,7 +113,7 @@ export default class Elements extends React.Component<Props, State> {
   };
 
   handleUnregisterElement = (el: Object) => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       registeredElements: prevState.registeredElements.filter(
         ({element}) => element !== el
       ),

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -66,7 +66,7 @@ describe('Elements', () => {
   it('with async context: addElementsLoadListener returns the same elements instance ', () => {
     const asyncContext = {
       tag: 'async',
-      addStripeLoadListener: jest.fn(callback =>
+      addStripeLoadListener: jest.fn((callback) =>
         setTimeout(() => callback(stripeMock), 0)
       ),
     };
@@ -78,14 +78,14 @@ describe('Elements', () => {
     );
     const childContext = wrapper.node.getChildContext();
 
-    const a = new Promise(resolve =>
-      childContext.addElementsLoadListener(first => {
+    const a = new Promise((resolve) =>
+      childContext.addElementsLoadListener((first) => {
         expect(first).toEqual(true);
         resolve();
       })
     );
-    const b = new Promise(resolve =>
-      childContext.addElementsLoadListener(second => {
+    const b = new Promise((resolve) =>
+      childContext.addElementsLoadListener((second) => {
         expect(second).toEqual(true);
         resolve();
       })

--- a/src/components/PaymentRequestButtonElement.test.js
+++ b/src/components/PaymentRequestButtonElement.test.js
@@ -24,7 +24,7 @@ describe('PaymentRequestButtonElement', () => {
       create: jest.fn().mockReturnValue(elementMock),
     };
     context = {
-      addElementsLoadListener: fn => fn(elementsMock),
+      addElementsLoadListener: (fn) => fn(elementsMock),
       registerElement: jest.fn(),
       unregisterElement: jest.fn(),
     };

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -12,7 +12,7 @@ type Meta =
   | {tag: 'sync', stripe: StripeShape}
   | {tag: 'async', stripe: StripeShape | null};
 
-type StripeLoadListener = StripeShape => void;
+type StripeLoadListener = (StripeShape) => void;
 
 // TODO(jez) 'sync' and 'async' are bad tag names.
 // TODO(jez) What if redux also uses this.context.tag?
@@ -22,7 +22,7 @@ export type SyncStripeContext = {
 };
 export type AsyncStripeContext = {
   tag: 'async',
-  addStripeLoadListener: StripeLoadListener => void,
+  addStripeLoadListener: (StripeLoadListener) => void,
 };
 
 export type ProviderContext = SyncStripeContext | AsyncStripeContext;
@@ -172,7 +172,7 @@ export default class Provider extends React.Component<Props> {
       this._didWakeUpListeners = true;
       const stripe = ensureStripeShape(nextProps.stripe);
       this._meta.stripe = stripe;
-      this._listeners.forEach(fn => {
+      this._listeners.forEach((fn) => {
         fn(stripe);
       });
     }

--- a/src/components/Provider.test.js
+++ b/src/components/Provider.test.js
@@ -127,7 +127,7 @@ describe('StripeProvider', () => {
     expect(childContext).toHaveProperty('tag', 'async');
   });
 
-  it('addStripeLoadListener is called when stripe goes from null -> non-null', done => {
+  it('addStripeLoadListener is called when stripe goes from null -> non-null', (done) => {
     const wrapper = mount(
       <StripeProvider stripe={null}>
         <form />
@@ -135,7 +135,7 @@ describe('StripeProvider', () => {
     );
 
     const childContext = wrapper.node.getChildContext();
-    childContext.addStripeLoadListener(stripe => {
+    childContext.addStripeLoadListener((stripe) => {
       expect(stripe).toEqual(stripeMockResult);
       done();
     });

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -103,11 +103,11 @@ Please be sure the component that calls createSource or createToken is within an
       specifiedType: string
     ): ?ElementShape => {
       const allElements = this.context.getRegisteredElements();
-      const filteredElements = allElements.filter(e => e[filterBy]);
+      const filteredElements = allElements.filter((e) => e[filterBy]);
       const matchingElements =
         specifiedType === 'auto'
           ? filteredElements
-          : filteredElements.filter(e => e[filterBy] === specifiedType);
+          : filteredElements.filter((e) => e[filterBy] === specifiedType);
 
       if (matchingElements.length === 1) {
         return matchingElements[0].element;
@@ -203,7 +203,7 @@ Please be sure the component that calls createSource or createToken is within an
           stripe={this.state.stripe}
           ref={
             withRef
-              ? c => {
+              ? (c) => {
                   this.wrappedInstance = c;
                 }
               : null

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -63,7 +63,7 @@ describe('injectStripe()', () => {
     it('throws when StripeProvider is missing from ancestry', () => {
       // Prevent the expected console.error from react to keep the test output clean
       const originalConsoleError = global.console.error;
-      global.console.error = msg => {
+      global.console.error = (msg) => {
         if (
           !msg.startsWith(
             'Warning: Failed context type: The context `tag` is marked as required'
@@ -316,7 +316,7 @@ describe('injectStripe()', () => {
         context: {
           tag: 'async',
           // simulate StripeProvider eventually giving us a StripeShape
-          addStripeLoadListener: fn => {
+          addStripeLoadListener: (fn) => {
             fn({
               elements: jest.fn(),
               createSource,

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -6,7 +6,7 @@ const shallowEqual = (a: Object, b: Object): boolean => {
 
   return (
     keysA.length === keysB.length &&
-    keysA.every(key => b.hasOwnProperty(key) && b[key] === a[key])
+    keysA.every((key) => b.hasOwnProperty(key) && b[key] === a[key])
   );
 };
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -5,12 +5,12 @@ const reactExternal = {
   root: 'React',
   commonjs2: 'react',
   commonjs: 'react',
-  amd: 'react'
+  amd: 'react',
 };
 
 const config = {
   externals: {
-    'react': reactExternal,
+    react: reactExternal,
   },
   module: {
     loaders: [


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

The IBAN Element demo creates a `sepa_debit` Source. Our recommendation in the docs is to also pass in `mandate: { notification_method: 'email' }` when creating the Source.

This PR adds that in the demo. It also fixes the glob pattern for the prettier command to reach more files.

### Testing & documentation

Manual. I made sure the Source was being created as expected in the demo.
