### PR TITLE
Set displayName for `Element` components

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -20,11 +20,15 @@ const _extractOptions = (props: Props): Object => {
   return options;
 };
 
+const capitalized = (str: string) => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
 const Element = (
   type: string,
   hocOptions: {impliedTokenType?: string, impliedSourceType?: string} = {}
-) => {
-  class ElementWrapper extends React.Component<Props> {
+) =>
+  class extends React.Component<Props> {
     static propTypes = {
       id: PropTypes.string,
       className: PropTypes.string,
@@ -43,6 +47,8 @@ const Element = (
     };
 
     static contextTypes = elementContextTypes;
+
+    static displayName = `${capitalized(type)}Element`;
 
     constructor(props: Props, context: ElementContext) {
       super(props, context);
@@ -127,12 +133,6 @@ const Element = (
         />
       );
     }
-  }
-
-  const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
-  ElementWrapper.displayName = `${typeCapitalized}Element`;
-
-  return ElementWrapper;
-};
+  };
 
 export default Element;

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -23,8 +23,8 @@ const _extractOptions = (props: Props): Object => {
 const Element = (
   type: string,
   hocOptions: {impliedTokenType?: string, impliedSourceType?: string} = {}
-) =>
-  class extends React.Component<Props> {
+) => {
+  class ElementWrapper extends React.Component<Props> {
     static propTypes = {
       id: PropTypes.string,
       className: PropTypes.string,
@@ -127,6 +127,12 @@ const Element = (
         />
       );
     }
-  };
+  }
+
+  const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
+  ElementWrapper.displayName = `${typeCapitalized}Element`;
+
+  return ElementWrapper;
+};
 
 export default Element;

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -139,4 +139,9 @@ describe('Element', () => {
 
     expect(() => element.setProps({placeholder: 'placeholder'})).not.toThrow();
   });
+
+  it('should have a displayName based on the type argument', () => {
+    const TestElement = Element('test');
+    expect(TestElement.displayName).toEqual('TestElement');
+  });
 });


### PR DESCRIPTION
### Summary & motivation

This PR adds `displayName` to any component wrapped by the `Element` HOC. `displayName` is useful for debugging. 

#### In the React devtools, before:
<img width="396" alt="screen shot 2018-07-11 at 4 18 17 pm" src="https://user-images.githubusercontent.com/10764257/42597214-128a64fa-8526-11e8-8016-d62cb2dfb44a.png">

#### After:
<img width="397" alt="screen shot 2018-07-11 at 4 19 52 pm" src="https://user-images.githubusercontent.com/10764257/42597287-491a156a-8526-11e8-98a1-51da293aaaa1.png">