### PR TITLE
[docs] Clarify `createToken` and `createSource` wrap methods of the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,11 +636,11 @@ The following props will be available to this component:
 ```js
 type FactoryProps = {
   stripe: null | {
-    createToken: (tokenParameters: {type?: string}) => Promise<{
+    createToken: (tokenData: {type?: string}) => Promise<{
       token?: Object,
       error?: Object,
     }>,
-    createSource: (sourceParameters: {type?: string}) => Promise<{
+    createSource: (sourceData: {type?: string}) => Promise<{
       source?: Object,
       error?: Object,
     }>,

--- a/README.md
+++ b/README.md
@@ -620,6 +620,12 @@ Components that need to initiate Source or Token creations (e.g. a checkout form
 component) can access `stripe.createToken` or `stripe.createSource` via props of
 any component returned by the `injectStripe` HOC factory.
 
+Within the context of `Elements`, `stripe.createToken` and `stripe.createSource`
+wrap methods of the same name in
+[Stripe.js](https://stripe.com/docs/stripe-js/reference#stripe-create-Token).
+Calls to them automatically infer and pass the `Element` object as the first
+argument.
+
 If the `withRef` option is set to `true`, the wrapped component instance will be
 available with the `getWrappedInstance()` method of the wrapper component. This
 feature can not be used if the wrapped component is a stateless function


### PR DESCRIPTION
### Summary & motivation

I was confused at first, assuming that `stripe.createToken` and `stripe.createSource` are the same methods as Stripe.js's [`createToken`](https://stripe.com/docs/stripe-js/reference#stripe-create-token) and [`createSource`](https://stripe.com/docs/stripe-js/reference#stripe-create-source). Turns out there's a bit of magic, so this is an attempt to document this.

I struggled to come up with a concise explanation and identify a good place to place the clarification, so feedback welcome!


#####  For more context, this is the rough logic of how I arrived at my conclusion. True story.
1. I want to create a source, so I search for `createSource` in the README, and see this:
![image](https://user-images.githubusercontent.com/42195497/44554381-95751500-a6e5-11e8-9e89-d83daf640c67.png)
2. Got it, I should go check out: https://stripe.com/docs/stripe-js/reference#stripe-create-source
3. Hmm the first thing I see doesn't match the function signature:
![image](https://user-images.githubusercontent.com/42195497/44554412-b63d6a80-a6e5-11e8-87b4-b19a90e7ef3a.png)
4. Scroll down some more and see a function that matches the signature:
![image](https://user-images.githubusercontent.com/42195497/44554441-d40acf80-a6e5-11e8-82be-593331075e63.png)
5. But wait... it says I cannot pass raw card information.
![image](https://user-images.githubusercontent.com/42195497/44554447-dec56480-a6e5-11e8-8825-41d87538adf8.png)
6. Wait, I am using Elements, but I'm also sending raw card info. What's going on?!
7. Ok, so I should call `createToken` first, then call `createSource`? (Based on "You can also pass an existing card token to convert it into a Source object.")
8.  `¯\_(ツ)_/¯`

### Testing & documentation

Documentation change: 👀 
