### PR TITLE
Clarify docs for `injectStripe` and async flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,9 @@ class App extends React.Component {
 
 Inside `<InjectedCheckoutForm />`, `this.props.stripe` will either be `null` or
 a Stripe instance. React will re-render `<InjectedCheckoutForm>` when
-`this.props.stripe` changes from `null` to a Stripe instance. Note that when
-providing Stripe.js asynchronously, you can still wrap a component returned by the
-[`injectStripe` HOC](#injectstripe-hoc).
+`this.props.stripe` changes from `null` to a Stripe instance. When loading Stripe.js asynchronously, the `stripe` prop provided by injectStripe will be initially null, and will become the Stripe instance once the instance is passed in.
+
+When loading Stripe.js asynchronously, the stripe prop provided by injectStripe will be initially null, and will become the Stripe instance once the instance is passed in.
 
 You can find a working demo of this strategy in [async.js](demo/async/async.js).
 If you run the demo locally, you can view it at <http://localhost:8080/async/>.
@@ -634,7 +634,7 @@ the `stripe` prop.
 class CheckoutForm extends React.Component {
   render() { /* ... */ }
   onCompleteCheckout() {
-    this.props.createSource().then(/* ... */)
+    this.props.stripe.createSource().then(/* ... */)
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -387,12 +387,7 @@ class App extends React.Component {
 }
 ```
 
-Inside `<InjectedCheckoutForm />`, `this.props.stripe` will either be `null` or
-a Stripe instance. React will re-render `<InjectedCheckoutForm>` when
-`this.props.stripe` changes from `null` to a Stripe instance. When loading Stripe.js asynchronously, the `stripe` prop provided by injectStripe will be initially null, and will become the Stripe instance once the instance is passed in.
-
-When loading Stripe.js asynchronously, the stripe prop provided by injectStripe will be initially null, and will become the Stripe instance once the instance is passed in.
-
+When loading Stripe.js asynchronously, the `stripe` prop provided by `injectStripe` will initially be `null`, and will update to the Stripe instance once you pass it in to your `StripeProvider`.
 You can find a working demo of this strategy in [async.js](demo/async/async.js).
 If you run the demo locally, you can view it at <http://localhost:8080/async/>.
 

--- a/README.md
+++ b/README.md
@@ -387,9 +387,11 @@ class App extends React.Component {
 }
 ```
 
-When loading Stripe.js asynchronously, the `stripe` prop provided by `injectStripe` will initially be `null`, and will update to the Stripe instance once you pass it in to your `StripeProvider`.
-You can find a working demo of this strategy in [async.js](demo/async/async.js).
-If you run the demo locally, you can view it at <http://localhost:8080/async/>.
+When loading Stripe.js asynchronously, the `stripe` prop provided by
+`injectStripe` will initially be `null`, and will update to the Stripe instance
+once you pass it in to your `StripeProvider`. You can find a working demo of
+this strategy in [async.js](demo/async/async.js). If you run the demo locally,
+you can view it at <http://localhost:8080/async/>.
 
 For alternatives to calling `setState`in `componentDidMount`, consider using a
 `setTimeout()`, moving the `if/else` statement to the `constructor`, or
@@ -613,23 +615,26 @@ function injectStripe(
 ): ReactClass;
 ```
 
-Use `injectStripe` to wrap a component that needs to interact with `Stripe.js` to
-create sources or tokens. 
+Use `injectStripe` to wrap a component that needs to interact with `Stripe.js`
+to create sources or tokens.
 
-1. First, create a component that accepts the `stripe` prop and calls
-`this.props.stripe.createToken` or `this.props.stripe.createSource` when necessary.
-2. Wrap that component by passing it to `injectStripe` so that it actually receives
-the `stripe` prop.
-3. Render the component that `injectStripe` returns.
+1.  First, create a component that accepts the `stripe` prop and calls
+    `this.props.stripe.createToken` or `this.props.stripe.createSource` when
+    necessary.
+2.  Wrap that component by passing it to `injectStripe` so that it actually
+    receives the `stripe` prop.
+3.  Render the component that `injectStripe` returns.
 
 ### Example
 
 ```js
 // 1. Create a component that uses this.props.stripe:
 class CheckoutForm extends React.Component {
-  render() { /* ... */ }
+  render() {
+    /* ... */
+  }
   onCompleteCheckout() {
-    this.props.stripe.createSource().then(/* ... */)
+    this.props.stripe.createSource().then(/* ... */);
   }
 }
 
@@ -637,13 +642,17 @@ class CheckoutForm extends React.Component {
 const InjectedCheckoutForm = injectStripe(CheckoutForm);
 
 // 3. Render the wrapped component in your app:
-const CheckoutRoute = (props) => <div><InjectedCheckoutForm/></div>
+const CheckoutRoute = (props) => (
+  <div>
+    <InjectedCheckoutForm />
+  </div>
+);
 ```
 
-`injectStripe` will work with any method of providing the actual Stripe instance with
-`StripeProvider`, whether you just give it an api key,
-[load Stripe.js asynchronously](#loading-stripejs-asynchronously),
-or [pass in an existing instance](#using-an-existing-stripe-instance).
+`injectStripe` will work with any method of providing the actual Stripe instance
+with `StripeProvider`, whether you just give it an api key,
+[load Stripe.js asynchronously](#loading-stripejs-asynchronously), or
+[pass in an existing instance](#using-an-existing-stripe-instance).
 
 Within the context of `Elements`, `stripe.createToken` and `stripe.createSource`
 wrap methods of the same name in
@@ -677,9 +686,9 @@ type FactoryProps = {
 
 The `stripe` prop can only be `null` if you are using one of the
 [Advanced integrations](#advanced-integrations) mentioned above, like loading
-Stripe.js asynchronously or providing an existing instance. If you are using
-a basic integration where you pass in an api key to `<StripeProvider/>`, it 
-will always be present.
+Stripe.js asynchronously or providing an existing instance. If you are using a
+basic integration where you pass in an api key to `<StripeProvider/>`, it will
+always be present.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,9 @@ class App extends React.Component {
 
 Inside `<InjectedCheckoutForm />`, `this.props.stripe` will either be `null` or
 a Stripe instance. React will re-render `<InjectedCheckoutForm>` when
-`this.props.stripe` changes from `null` to a Stripe instance.
+`this.props.stripe` changes from `null` to a Stripe instance. Note that when
+providing Stripe.js asynchronously, you can still wrap a component returned by the
+[`injectStripe` HOC](#injectstripe-hoc).
 
 You can find a working demo of this strategy in [async.js](demo/async/async.js).
 If you run the demo locally, you can view it at <http://localhost:8080/async/>.
@@ -616,9 +618,37 @@ function injectStripe(
 ): ReactClass;
 ```
 
-Components that need to initiate Source or Token creations (e.g. a checkout form
-component) can access `stripe.createToken` or `stripe.createSource` via props of
-any component returned by the `injectStripe` HOC factory.
+Use `injectStripe` to wrap a component that needs to interact with `Stripe.js` to
+create sources or tokens. 
+
+1. First, create a component that accepts the `stripe` prop and calls
+`this.props.stripe.createToken` or `this.props.stripe.createSource` when necessary.
+2. Wrap that component by passing it to `injectStripe` so that it actually receives
+the `stripe` prop.
+3. Render the component that `injectStripe` returns.
+
+### Example
+
+```js
+// 1. Create a component that uses this.props.stripe:
+class CheckoutForm extends React.Component {
+  render() { /* ... */ }
+  onCompleteCheckout() {
+    this.props.createSource().then(/* ... */)
+  }
+}
+
+// 2. Wrap it in a higher-order component that provides the `stripe` prop:
+const InjectedCheckoutForm = injectStripe(CheckoutForm);
+
+// 3. Render the wrapped component in your app:
+const CheckoutRoute = (props) => <div><InjectedCheckoutForm/></div>
+```
+
+`injectStripe` will work with any method of providing the actual Stripe instance with
+`StripeProvider`, whether you just give it an api key,
+[load Stripe.js asynchronously](#loading-stripejs-asynchronously),
+or [pass in an existing instance](#using-an-existing-stripe-instance).
 
 Within the context of `Elements`, `stripe.createToken` and `stripe.createSource`
 wrap methods of the same name in
@@ -631,13 +661,7 @@ available with the `getWrappedInstance()` method of the wrapper component. This
 feature can not be used if the wrapped component is a stateless function
 component.
 
-#### Example
-
-```js
-const InjectedCheckoutForm = injectStripe(CheckoutForm);
-```
-
-The following props will be available to this component:
+Within the wrapped component, the `stripe` prop has the type:
 
 ```js
 type FactoryProps = {
@@ -656,8 +680,11 @@ type FactoryProps = {
 };
 ```
 
-`stripe` is only `null` when using one of the
-[Advanced integrations](#advanced-integrations) mentioned above.
+The `stripe` prop can only be `null` if you are using one of the
+[Advanced integrations](#advanced-integrations) mentioned above, like loading
+Stripe.js asynchronously or providing an existing instance. If you are using
+a basic integration where you pass in an api key to `<StripeProvider/>`, it 
+will always be present.
 
 ## Troubleshooting
 


### PR DESCRIPTION
r? @atty-stripe 

In #160, a user quite reasonably got confused by our docs on the async loading integration and the usage of `injectStripe`. Also, when I went back to try to edit the docs, I found myself getting confused by what was there. Thus this diff was born.

This PR aims to clarify a few things:
1. The method of "providing" the stripe instance at the top level of your app is independent of the method of "injecting" the stripe instance. (With the exception of it possibly being null in some cases.)
2. Using `injectStripe` isn't that complicated, even if you don't know what a higher-order component is. I've broken out the three steps with the goal of showing people what to do and why.