### PR TITLE
Fix expected params for createSource in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ class CheckoutForm extends React.Component {
     // You can also use createSource to create Sources. See our Sources
     // documentation for more: https://stripe.com/docs/stripe-js/reference#stripe-create-source
     //
-    // this.props.stripe.createSource({type: 'card', name: 'Jenny Rosen'});
-  };
+    // this.props.stripe.createSource({type: 'card', owner: {
+    //   name: 'Jenny Rosen'
+    // }});
 
   render() {
     return (
@@ -634,7 +635,7 @@ class CheckoutForm extends React.Component {
     /* ... */
   }
   onCompleteCheckout() {
-    this.props.stripe.createSource().then(/* ... */);
+    this.props.stripe.createSource({type: 'card'}).then(/* ... */);
   }
 }
 
@@ -674,7 +675,7 @@ type FactoryProps = {
       token?: Object,
       error?: Object,
     }>,
-    createSource: (sourceData: {type?: string}) => Promise<{
+    createSource: (sourceData: {type: string}) => Promise<{
       source?: Object,
       error?: Object,
     }>,


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

`stripe.createSource` requires `type` being passed in, but our README did not reflect this.

See https://github.com/stripe/react-stripe-elements/issues/253#issuecomment-426154651 for reference.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Manual.
