### PR TITLE
Use deep equal for options update checks

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowEqual from '../utils/shallowEqual';
+import isEqual from '../utils/isEqual';
 import {type ElementContext, elementContextTypes} from './Elements';
 
 type Props = {
@@ -85,7 +85,7 @@ const Element = (
       const options = _extractOptions(nextProps);
       if (
         Object.keys(options).length !== 0 &&
-        !shallowEqual(options, this._options)
+        !isEqual(options, this._options)
       ) {
         this._options = options;
         if (this._element) {

--- a/src/utils/isEqual.js
+++ b/src/utils/isEqual.js
@@ -1,0 +1,49 @@
+// @flow
+const PLAIN_OBJECT_STR = '[object Object]';
+
+const isEqual = (left: mixed, right: mixed): boolean => {
+  if (typeof left !== 'object' || typeof right !== 'object') {
+    return left === right;
+  }
+
+  if (left === null || right === null) return left === right;
+
+  const leftArray = Array.isArray(left);
+  const rightArray = Array.isArray(right);
+
+  if (leftArray !== rightArray) return false;
+
+  const leftPlainObject =
+    Object.prototype.toString.call(left) === PLAIN_OBJECT_STR;
+  const rightPlainObject =
+    Object.prototype.toString.call(right) === PLAIN_OBJECT_STR;
+
+  if (leftPlainObject !== rightPlainObject) return false;
+
+  if (!leftPlainObject && !leftArray) return false;
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+
+  if (leftKeys.length !== rightKeys.length) return false;
+
+  const keySet = {};
+  for (let i = 0; i < leftKeys.length; i += 1) {
+    keySet[leftKeys[i]] = true;
+  }
+  for (let i = 0; i < rightKeys.length; i += 1) {
+    keySet[rightKeys[i]] = true;
+  }
+  const allKeys = Object.keys(keySet);
+  if (allKeys.length !== leftKeys.length) {
+    return false;
+  }
+
+  const pred = (key) => {
+    return isEqual(left[key], right[key]);
+  };
+
+  return allKeys.every(pred);
+};
+
+export default isEqual;

--- a/src/utils/isEqual.js
+++ b/src/utils/isEqual.js
@@ -39,8 +39,10 @@ const isEqual = (left: mixed, right: mixed): boolean => {
     return false;
   }
 
+  const l = left;
+  const r = right;
   const pred = (key) => {
-    return isEqual(left[key], right[key]);
+    return isEqual(l[key], r[key]);
   };
 
   return allKeys.every(pred);

--- a/src/utils/isEqual.test.js
+++ b/src/utils/isEqual.test.js
@@ -1,0 +1,51 @@
+// @noflow
+import isEqual from './isEqual';
+
+describe('isEqual', () => {
+  [
+    ['a', 'a'],
+    [100, 100],
+    [false, false],
+    [undefined, undefined],
+    [null, null],
+    [{}, {}],
+    [{a: 10}, {a: 10}],
+    [{a: null}, {a: null}],
+    [{a: undefined}, {a: undefined}],
+    [[], []],
+    [['a', 'b', 'c'], ['a', 'b', 'c']],
+    [['a', {inner: [12]}, 'c'], ['a', {inner: [12]}, 'c']],
+    [{a: {nested: {more: [1, 2, 3]}}}, {a: {nested: {more: [1, 2, 3]}}}],
+  ].forEach(([left, right]) => {
+    it(`should should return true for isEqual(${JSON.stringify(
+      left
+    )}, ${JSON.stringify(right)})`, () => {
+      expect(isEqual(left, right)).toBe(true);
+      expect(isEqual(right, left)).toBe(true);
+    });
+  });
+
+  [
+    ['a', 'b'],
+    ['0', 0],
+    [new Date(1), {}],
+    [false, ''],
+    [false, true],
+    [null, undefined],
+    [{}, []],
+    [/foo/, /foo/],
+    [new Date(1), new Date(1)],
+    [{a: 10}, {a: 11}],
+    [['a', 'b', 'c'], ['a', 'b', 'c', 'd']],
+    [['a', 'b', 'c', 'd'], ['a', 'b', 'c']],
+    [['a', {inner: [12]}, 'c'], ['a', {inner: [null]}, 'c']],
+    [{a: {nested: {more: [1, 2, 3]}}}, {b: {nested: {more: [1, 2, 3]}}}],
+  ].forEach(([left, right]) => {
+    it(`should should return false for isEqual(${JSON.stringify(
+      left
+    )}, ${JSON.stringify(right)})`, () => {
+      expect(isEqual(left, right)).toBe(false);
+      expect(isEqual(right, left)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Summary & motivation

This switches the check for changed option to use a deep equal instead of the previous shallow one.
The options have nested object shape (e.g. the `style` attribute is in itself a nested object), so if we truly do not want to call `element.update` if the options have not changes, we need a more thorough equal check.

This addresses #290

### Testing & documentation

Added unit tests.
