### PR TITLE
[WIP]First commit: add support for paymentmethod

### DIFF
--- a/demo/async/async.js
+++ b/demo/async/async.js
@@ -44,9 +44,12 @@ class _CardForm extends React.Component<InjectedProps> {
   handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
+      // this.props.stripe
+      //   .createToken()
+      //   .then((payload) => console.log('[token]', payload));
       this.props.stripe
-        .createToken()
-        .then((payload) => console.log('[token]', payload));
+        .createPaymentMethod()
+        .then((payload) => console.log('[paymentMethod]', payload));
     } else {
       console.log('Form submitted before Stripe.js loaded.');
     }

--- a/demo/demo/index.js
+++ b/demo/demo/index.js
@@ -58,9 +58,12 @@ class _CardForm extends React.Component<InjectedProps & {fontSize: string}> {
   handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
+      // this.props.stripe
+      //   .createToken()
+      //   .then((payload) => console.log('[token]', payload));
       this.props.stripe
-        .createToken()
-        .then((payload) => console.log('[token]', payload));
+        .createPaymentMethod()
+        .then((payload) => console.log('[paymentMethod]', payload));
     } else {
       console.log("Stripe.js hasn't loaded yet.");
     }
@@ -89,9 +92,12 @@ class _SplitForm extends React.Component<InjectedProps & {fontSize: string}> {
   handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
+      // this.props.stripe
+      //   .createToken()
+      //   .then((payload) => console.log('[token]', payload));
       this.props.stripe
-        .createToken()
-        .then((payload) => console.log('[token]', payload));
+        .createPaymentMethod()
+        .then((payload) => console.log('[paymentMethod]', payload));
     } else {
       console.log("Stripe.js hasn't loaded yet.");
     }

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -18,6 +18,7 @@ describe('Elements', () => {
         .mockReturnValueOnce(true),
       createToken: jest.fn(),
       createSource: jest.fn(),
+      createPaymentMethod: jest.fn(),
     };
   });
 

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -51,7 +51,7 @@ const getOrCreateStripe = (apiKey: string, options: mixed): StripeShape => {
 };
 
 const ensureStripeShape = (stripe: mixed): StripeShape => {
-  if (stripe && stripe.elements && stripe.createSource && stripe.createToken) {
+  if (stripe && stripe.elements && stripe.createSource && stripe.createToken && stripe.createPaymentMethod) {
     return ((stripe: any): StripeShape);
   } else {
     throw new Error(

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -51,7 +51,13 @@ const getOrCreateStripe = (apiKey: string, options: mixed): StripeShape => {
 };
 
 const ensureStripeShape = (stripe: mixed): StripeShape => {
-  if (stripe && stripe.elements && stripe.createSource && stripe.createToken && stripe.createPaymentMethod) {
+  if (
+    stripe &&
+    stripe.elements &&
+    stripe.createSource &&
+    stripe.createToken &&
+    stripe.createPaymentMethod
+  ) {
     return ((stripe: any): StripeShape);
   } else {
     throw new Error(

--- a/src/components/Provider.test.js
+++ b/src/components/Provider.test.js
@@ -13,6 +13,7 @@ describe('StripeProvider', () => {
       elements: jest.fn(),
       createToken: jest.fn(),
       createSource: jest.fn(),
+      createPaymentMethod: jest.fn(),
     };
     stripeMockFn = jest.fn().mockReturnValue(stripeMockResult);
     window.Stripe = stripeMockFn;

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -206,8 +206,8 @@ Please be sure the component that calls createSource or createToken is within an
     ) => {
       if (!['card'].includes(paymentMethodType)) {
         throw new Error(
-            `Invalid PaymentMethod type passed to createPaymentMethod. ${paymentMethodType} is not yet supported.`
-          );
+          `Invalid PaymentMethod type passed to createPaymentMethod. ${paymentMethodType} is not yet supported.`
+        );
       }
 
       if (paymentMethodType && typeof paymentMethodType === 'string') {

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -273,7 +273,11 @@ describe('injectStripe()', () => {
 
       const props = wrapper.props();
       props.stripe.createPaymentMethod('card');
-      expect(createPaymentMethod).toHaveBeenCalledWith('card', elementMock.element, {});
+      expect(createPaymentMethod).toHaveBeenCalledWith(
+        'card',
+        elementMock.element,
+        {}
+      );
     });
 
     it('props.stripe.createPaymentMethod calls createPaymentMethod with data options', () => {
@@ -289,11 +293,15 @@ describe('injectStripe()', () => {
           name: 'Jenny Rosen',
         },
       });
-      expect(createPaymentMethod).toHaveBeenCalledWith('card', elementMock.element, {
-        billing_details: {
-          name: 'Jenny Rosen',
-        },
-      });
+      expect(createPaymentMethod).toHaveBeenCalledWith(
+        'card',
+        elementMock.element,
+        {
+          billing_details: {
+            name: 'Jenny Rosen',
+          },
+        }
+      );
     });
 
     it('throws when `getWrappedInstance` is called without `{withRef: true}` option.', () => {

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -9,12 +9,14 @@ describe('injectStripe()', () => {
   let context;
   let createSource;
   let createToken;
+  let createPaymentMethod;
   let elementMock;
 
   // Before ALL tests (sync or async)
   beforeEach(() => {
     createSource = jest.fn();
     createToken = jest.fn();
+    createPaymentMethod = jest.fn();
     elementMock = {
       element: {
         on: jest.fn(),
@@ -35,6 +37,7 @@ describe('injectStripe()', () => {
           elements: jest.fn(),
           createSource,
           createToken,
+          createPaymentMethod,
         },
         getRegisteredElements: () => [elementMock],
       };
@@ -95,6 +98,7 @@ describe('injectStripe()', () => {
       expect(props).toHaveProperty('stripe');
       expect(props).toHaveProperty('stripe.createSource');
       expect(props).toHaveProperty('stripe.createToken');
+      expect(props).toHaveProperty('stripe.createPaymentMethod');
     });
 
     it('props.stripe.createToken calls createToken with element and empty options when called with no arguments', () => {
@@ -260,6 +264,38 @@ describe('injectStripe()', () => {
       );
     });
 
+    it('props.stripe.createPaymentMethod calls createPaymentMethod with element and type when only type is passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createPaymentMethod('card');
+      expect(createPaymentMethod).toHaveBeenCalledWith('card', elementMock.element, {});
+    });
+
+    it('props.stripe.createPaymentMethod calls createPaymentMethod with data options', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createPaymentMethod('card', {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+      expect(createPaymentMethod).toHaveBeenCalledWith('card', elementMock.element, {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+    });
+
     it('throws when `getWrappedInstance` is called without `{withRef: true}` option.', () => {
       const Injected = injectStripe(WrappedComponent);
 
@@ -321,6 +357,7 @@ describe('injectStripe()', () => {
               elements: jest.fn(),
               createSource,
               createToken,
+              createPaymentMethod,
             });
           },
           getRegisteredElements: () => [elementMock],
@@ -331,6 +368,7 @@ describe('injectStripe()', () => {
       expect(props).toHaveProperty('stripe');
       expect(props).toHaveProperty('stripe.createToken');
       expect(props).toHaveProperty('stripe.createSource');
+      expect(props).toHaveProperty('stripe.createPaymentMethod');
     });
   });
 });

--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -25,4 +25,9 @@ declare type StripeShape = {
     type: string | ElementShape,
     options: mixed
   ) => Promise<{token?: MixedObject, error?: MixedObject}>,
+  createPaymentMethod: (
+    type: string,
+    element: ElementShape,
+    data: mixed,
+  ) => Promise<{paymentMethod?: MixedObject, error?: MixedObject}>,
 };

--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -28,6 +28,6 @@ declare type StripeShape = {
   createPaymentMethod: (
     type: string,
     element: ElementShape,
-    data: mixed,
+    data: mixed
   ) => Promise<{paymentMethod?: MixedObject, error?: MixedObject}>,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const CardElement = Element('card', {
 const CardNumberElement = Element('cardNumber', {
   impliedTokenType: 'card',
   impliedSourceType: 'card',
+  impliedPaymentMethodType: 'card',
 });
 const CardExpiryElement = Element('cardExpiry');
 const CardCVCElement = Element('cardCvc');


### PR DESCRIPTION
### Summary & motivation
Still *WIP*, will complete it along the way but put it up for commenting.

Similar to `createToken`, `createSource`. It will be great if we could automatically infer element for
- [ ] createPaymentMethod
- [ ] handleCardPayment
This is the first step to support createPaymentMethod

### Testing & documentation
- Write unit test for createPaymentMethod 
- Put createPaymentMethod in demo (ToDo: probably should exist side by side with createToken)


### To Do
- [ ] `impliedSourceType` -> `impliedPaymentMethod`
- [ ] add `handleCardPayment`
- [ ] Add demo support side by side with existing code

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
