### PR TITLE
remove PostalCodeElement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ const CardNumberElement = Element('cardNumber', {
 });
 const CardExpiryElement = Element('cardExpiry');
 const CardCVCElement = Element('cardCvc');
-const PostalCodeElement = Element('postalCode');
 
 // IBAN
 const IbanElement = Element('iban', {
@@ -42,7 +41,6 @@ export {
   CardNumberElement,
   CardExpiryElement,
   CardCVCElement,
-  PostalCodeElement,
   PaymentRequestButtonElement,
   IbanElement,
   IdealBankElement,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,7 +10,6 @@ import {
   CardNumberElement,
   CardExpiryElement,
   CardCVCElement,
-  PostalCodeElement,
 } from './index';
 
 class PureWrapper extends React.PureComponent {
@@ -122,7 +121,6 @@ describe('index', () => {
               <CardNumberElement />
               <CardExpiryElement />
               <CardCVCElement />
-              <PostalCodeElement />
             </Checkout>
           </Elements>
         </StripeProvider>


### PR DESCRIPTION
### Summary & motivation
Removes support for the PostalCodeElement as it is no longer the recommended way to collect postal code. Users are suggested to build their own postal code input.

### Testing & documentation
Updated tests to reflect removal.