### PR TITLE
V3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### New Features
 
+- added a [changelog](/CHANGELOG.md)
 - added support for `stripe.handleCardPayment` and `stripe.createPaymentMethod`.
   These methods allow you to easily integrate Stripe's new Payment Intents API.
   Like `createToken` and `createSource`, these new methods will automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,60 @@
 - If you were already using `handleCardPayment` or `createPaymentMethod` with
   `react-stripe-elements`, you should upgrade your integration. These methods
   will now automatically find and use valid Elements.
-- Beta versions of Payment Intents with Stripe.js are not supported.
-- `PostalCodeElement` has been removed. Users are suggested to build their own
+
+  #### Old Way
+
+  ```js
+  <CardElement
+    ...
+    onReady={this.handleReady}
+  />
+
+  handleReady = (element) => {
+    this.setState({cardElement: element}) ;
+  };
+
+  let { paymentIntent, error } = await this.props.stripe.handleCardPayment(
+    intent.client_secret, this.state.cardElement, {}
+  );
+  ```
+
+  #### New Way
+
+  ```js
+  <CardElement />;
+
+  let {paymentIntent, error} = await this.props.stripe.handleCardPayment(
+    intent.client_secret,
+    {}
+  );
+  ```
+
+- Passing a beta flag to Stripe.js to use one of the PaymentIntents betas is not
+  supported.
+
+  #### Old Way
+
+  ```js
+  const stripe = window.Stripe(
+    publicKey,
+    {betas: ['payment_intent_beta_3']},
+  );
+
+  <StripeProvider stripe={stripe}>
+    <YourCheckoutComponent>
+  </StripeProvider>
+  ```
+
+  #### New Way
+
+  ```js
+  <StripeProvider apiKey={publicKey}>
+    <YourCheckoutComponent>
+  </StripeProvider>
+  ```
+
+- `PostalCodeElement` has been removed. We suggest that you build your own
   postal code input.
 
 ## v2.0.3 - 2019-01-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,223 @@
+# Changelog
+
+`react-stripe-elements` adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v3.0.0 - 2019-04-17
+
+### New Features
+
+- added support for `stripe.handleCardPayment` and `stripe.createPaymentMethod`.
+  These methods allow you to easily integrate Stripe's new Payment Intents API.
+  Like `createToken` and `createSource`, these new methods will automatically
+  find and use a corresponding Element when they are called.
+
+  ```js
+    stripe.createPaymentMethod(
+      paymentMethodType: string,
+      paymentMethodDetails: Object
+    ): Promise<{error?: Object, paymentIntent?: Object}>
+
+    stripe.handleCardPayment(
+      clientSecret: string,
+      paymentMethodDetails: Object
+    ): Promise<{error?: Object, paymentIntent?: Object}>
+  ```
+
+  For more information, please review the Stripe Docs:
+
+  - [`stripe.createPaymentMethod`](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method)
+  - [`stripe.handleCardPayment`](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment)
+  - [Payment Intents API](https://stripe.com/docs/payments/payment-intents)
+  - [Payment Methods API](https://stripe.com/docs/payments/payment-methods)
+
+### Breaking Changes:
+
+- If you were already using `handleCardPayment` or `createPaymentMethod` with
+  `react-stripe-elements`, you should upgrade your integration. These methods
+  will now automatically find and use valid Elements.
+- Beta versions of Payment Intents with Stripe.js are not supported.
+- `PostalCodeElement` has been removed. Users are suggested to build their own
+  postal code input.
+
+## v2.0.3 - 2019-01-25
+
+### Bug Fixes
+
+- Fixes a bug where the elements.update event was triggered far too often,
+  incorrectly, when an Element was repeatedly rendered with the same options.
+
+## v2.0.1 - 2018-07-11
+
+### Bug Fixes
+
+- The Element higher-order component now reports a proper displayName, which is
+  more useful for debugging. (Thanks @emilrose!)
+
+## v2.0.0 - 2018-06-01
+
+### New Features
+
+- Support for the `IbanElement` and `IdealBankElement`.
+
+### Breaking Changes
+
+- `stripe.createSource` now requires the Source type be passed in.
+  - For example, if you previously called
+    `stripe.createSource({ name: 'Jenny Rosen' })`, you now must use
+    `stripe.createSource({ type: 'card', name: 'Jenny Rosen' })`.
+- elementRef is no longer a valid prop you can pass to an `<Element />`. Use
+  onReady instead to get a reference to the underlying Element instance.
+
+## v1.7.0 - 2018-05-31
+
+### Deprecations
+
+- `createSource` automatically infers the type of Source to create based on
+  which Elements are in use. This behavior is now deprecated, and the Source
+  type will be required in version 2.0.0.
+
+## v1.6.0 - 2018-03-05
+
+### Deprecations
+
+- The elementRef callback is deprecated and will be removed in version 2.0.0.
+  Use onReady instead, which is the exact same.
+
+### Bug Fixes
+
+- The id prop from v1.5.0 was absent from the `PaymentRequestButtonElement`.
+  Now, the `PaymentRequestButtonElement` behaves like all the other \*Element
+  components.
+
+## v1.5.0 - 2018-03-02
+
+### New Features
+
+- (#177 / #178) The \*Element classes learned a new id prop. This can be used to
+  set the ID of the underlying DOM Element.
+
+## v1.4.1 - 2018-01-22
+
+### Bug Fixes
+
+- Fixed a TODO in an error message emitted by Provider.js.
+
+## v1.4.0 - 2018-01-17
+
+### Bug Fixes
+
+- Modify build pipeline to fix issues with IE9 and IE10.
+
+## v1.3.2 - 2018-01-11
+
+### Bug Fixes
+
+- Fix split Element token creation for async codepath. (#148)
+
+## v1.3.1 - 2018-01-10
+
+### Bug Fixes
+
+- Fixes a regression introduced by v1.3.0 (#146).
+
+## v1.3.0 - 2018-01-09
+
+### New Features
+
+- Loading Stripe.js and react-stripe-elements asynchronously
+- Rendering react-stripe-elements on the server
+- Passing a custom stripe instance to `StripeProvider`
+  - For an overview of how this works, see the Advanced integrations section.
+
+## v1.2.1 - 2017-11-21
+
+### Bug Fixes
+
+- Fixed a bug where using pure components under the `<Elements>` component would
+  lead to an error.
+
+## v1.2.0 - 2017-10-12
+
+### New Features
+
+- The PaymentRequestButtonElement now accepts an onClick prop that maps to the
+  `element.on('click')` event.
+
+## v1.1.1 - 2017-10-11
+
+### Bug Fixes
+
+- The instance of Stripe provided by StripeProvider is now consistent across
+  StripeProvider usages across your application, as long as you're passing in
+  the same API key & configuration.
+
+## v1.1.0 - 2017-10-05
+
+### New Features
+
+- We've added a new component! You can now use `<PaymentRequestButtonElement />`
+  which wraps up `elements.create('paymentRequestButton')` in a React component.
+
+## v1.0.0 - 2017-09-18
+
+### New Features
+
+- Update dependencies
+- Improve test coverage
+- Allow React 16 as peer dependency
+
+## v0.1.0 - 2017-09-13
+
+### New Features
+
+- You can now pass the `withRef` option to `injectStripe` to make the wrapped
+  component instance available via `getWrappedInstance()`
+
+## v0.0.8 - 2017-08-21
+
+### New Features
+
+- Render \*Element components with div instead of span (#61)
+
+## v0.0.7 - 2018-08-03
+
+### New Features
+
+- You can now pass `className` to `<*Element>` (e.g.
+  <CardElement className="foo"> and it will be passed down to the element
+  container DOM element.
+
+## v0.0.6 - 2017-07-25
+
+### Bug Fixes
+
+- Bugfix for collapsed Elements: #45 #48
+
+## v0.0.5 - 2017-07-20
+
+### Bug Fixes
+
+- Same as v0.0.3 but fixed corrupted npm upload.
+
+## v0.0.3 - 2017-07-20
+
+### Bug Fixes
+
+- Bug fixes for: #29, #40
+
+## v0.0.2 - 05-04-2017
+
+### New Features
+
+Initial release! Support for:
+
+- StripeProvider
+- Elements
+- injectStripe
+- Individual elements:
+  - CardElement
+  - CardNumberElement
+  - CardExpiryElement
+  - CardCVCElement
+  - PostalCodeElement

--- a/README.md
+++ b/README.md
@@ -166,9 +166,16 @@ Use the `injectStripe` [Higher-Order Component][hoc] (HOC) to build your payment
 form components in the `Elements` tree. The [Higher-Order Component][hoc]
 pattern in React can be unfamiliar to those who've never seen it before, so
 consider reading up before continuing. The `injectStripe` HOC provides the
-`this.props.stripe` property that manages your `Elements` groups. You can call
-`this.props.stripe.createToken` or `this.props.stripe.createSource` within a
-component that has been injected to submit payment data to Stripe.
+`this.props.stripe` property that manages your `Elements` groups. Within an
+injected component, you can call any of the following:
+
+- `this.props.stripe.createPaymentMethod`
+- `this.props.stripe.createToken`
+- `this.props.stripe.createSource`
+- `this.props.stripe.handleCardPayment`
+
+Calling any of these methods will collect data from the appropriate Element and
+use it to submit payment data to Stripe.
 
 [hoc]: https://facebook.github.io/react/docs/higher-order-components.html
 
@@ -191,22 +198,38 @@ class CheckoutForm extends React.Component {
     // We don't want to let default form submission happen here, which would refresh the page.
     ev.preventDefault();
 
-    // Within the context of `Elements`, this call to createToken knows which Element to
-    // tokenize, since there's only one in this group.
-    this.props.stripe.createToken({name: 'Jenny Rosen'}).then(({token}) => {
-      console.log('Received Stripe token:', token);
+    // Within the context of `Elements`, this call to createPaymentMethod knows from which Element to
+    // create the PaymentMethod, since there's only one in this group.
+    // See our createPaymentMethod documentation for more:
+    // https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method
+    this.props.stripe
+      .createPaymentMethod('card', {billing_details: {name: 'Jenny Rosen'}})
+      .then(({paymentMethod}) => {
+        console.log('Received Stripe PaymentMethod:', paymentMethod);
+      });
+
+    // You can also use handleCardPayment with the Payment Intents API automatic confirmation flow.
+    // See our handleCardPayment documentation for more:
+    // https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment
+    this.props.stripe.handleCardPayment('{PAYMENT_INTENT_CLIENT_SECRET}', data);
+
+    // You can also use createToken to create tokens.
+    // See our tokens documentation for more:
+    // https://stripe.com/docs/stripe-js/reference#stripe-create-token
+    this.props.stripe.createToken({type: 'card', name: 'Jenny Rosen'});
+    // token type can optionally be inferred if there is only one one Element
+    // with which to create tokens
+    // this.props.stripe.createToken({name: 'Jenny Rosen'});
+
+    // You can also use createSource to create Sources.
+    // See our Sources documentation for more:
+    // https://stripe.com/docs/stripe-js/reference#stripe-create-source
+    this.props.stripe.createSource({
+      type: 'card',
+      owner: {
+        name: 'Jenny Rosen',
+      },
     });
-
-    // However, this line of code will do the same thing:
-    //
-    // this.props.stripe.createToken({type: 'card', name: 'Jenny Rosen'});
-
-    // You can also use createSource to create Sources. See our Sources
-    // documentation for more: https://stripe.com/docs/stripe-js/reference#stripe-create-source
-    //
-    // this.props.stripe.createSource({type: 'card', owner: {
-    //   name: 'Jenny Rosen'
-    // }});
   };
 
   render() {
@@ -635,7 +658,7 @@ class CheckoutForm extends React.Component {
     /* ... */
   }
   onCompleteCheckout() {
-    this.props.stripe.createSource({type: 'card'}).then(/* ... */);
+    this.props.stripe.createPaymentMethod('card').then(/* ... */);
   }
 }
 
@@ -677,6 +700,20 @@ type FactoryProps = {
     }>,
     createSource: (sourceData: {type: string}) => Promise<{
       source?: Object,
+      error?: Object,
+    }>,
+    createPaymentMethod: (
+      type: string,
+      paymentMethodData?: Object
+    ) => Promise<{
+      paymentMethod?: Object,
+      error?: Object,
+    }>,
+    handleCardPayment: (
+      clientSecret: string,
+      paymentMethodData?: Object
+    ) => Promise<{
+      paymentIntent?: Object,
       error?: Object,
     }>,
     // and other functions available on the `stripe` object,

--- a/demo/paymentIntents/api.js
+++ b/demo/paymentIntents/api.js
@@ -1,0 +1,72 @@
+// @flow
+
+const {STRIPE_SECRET_KEY} = process.env;
+
+const serialize = (object: Object, scope: ?string): string => {
+  let result = [];
+  Object.keys(object).forEach((key) => {
+    const value = object[key];
+    const scopedKey = scope ? `${scope}[${key}]` : key;
+    if (value && typeof value === 'object') {
+      const nestedResult = serialize(value, scopedKey);
+      if (nestedResult !== '') {
+        result = [...result, nestedResult];
+      }
+    } else if (value !== undefined && value !== null) {
+      result = [...result, `${scopedKey}=${encodeURIComponent(String(value))}`];
+    }
+  });
+  return result.join('&').replace(/%20/g, '+');
+};
+
+const createPaymentIntent = (options: {}): Promise<string> => {
+  if (!STRIPE_SECRET_KEY) {
+    return Promise.reject(
+      new Error(
+        `A secret key is required to create PaymentIntents for handleCardPayment. Please set the following environment variable: \n\nSTRIPE_SECRET_KEY=<your secret key>`
+      )
+    );
+  }
+
+  // WARNING
+  // DO NOT USE THE FOLLOWING CODE IN A PRODUCTION APPLICATION!
+  // Your secret key should NEVER be used in on your frontend.
+  // We are doing this here purely for demonstration reasons.
+  // In the real world, creating PaymentIntents needs to be done
+  // on your backend server.
+  //
+  // Including your secret key on your frontend enables others
+  // to make charges on your behalf. Fraudsters will find your
+  // secret key and use it to test stolen card numbers, which will
+  // get your business banned from accepting credit card payments.
+  return window
+    .fetch(`https://api.stripe.com/v1/payment_intents`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: serialize(options),
+    })
+    .then((res) => {
+      if (res.status === 200) {
+        return res.json();
+      } else {
+        return null;
+      }
+    })
+    .then((data) => {
+      if (!data || data.error) {
+        console.log('API error:', {data});
+        throw new Error('PaymentIntent API Error');
+      } else {
+        return data.client_secret;
+      }
+    });
+};
+
+const api = {
+  createPaymentIntent,
+};
+
+export default api;

--- a/demo/paymentIntents/index.html
+++ b/demo/paymentIntents/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>demo | react-stripe-elements</title>
+    <script src="https://js.stripe.com/v3/"></script>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body,
+      html {
+        background-color: #f6f9fc;
+        font-size: 18px;
+        font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+      }
+
+      h1 {
+        color: #32325d;
+        font-weight: 400;
+        line-height: 50px;
+        font-size: 40px;
+        margin: 20px 0;
+        padding: 0;
+      }
+
+      .Checkout {
+        margin: 0 auto;
+        max-width: 800px;
+        box-sizing: border-box;
+        padding: 0 5px;
+      }
+
+      label {
+        color: #6b7c93;
+        font-weight: 300;
+        letter-spacing: 0.025em;
+      }
+
+      .error {
+        color: crimson;
+        font-size: 14px;
+        white-space: pre-wrap;
+        margin-bottom: 14px;
+      }
+
+      .message {
+        color: #6772e5;
+        font-size: 14px;
+        white-space: pre-wrap;
+        margin-bottom: 14px;
+      }
+
+      button {
+        white-space: nowrap;
+        border: 0;
+        outline: 0;
+        display: inline-block;
+        height: 40px;
+        line-height: 40px;
+        padding: 0 14px;
+        box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11),
+          0 1px 3px rgba(0, 0, 0, 0.08);
+        color: #fff;
+        border-radius: 4px;
+        font-size: 15px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.025em;
+        background-color: #6772e5;
+        text-decoration: none;
+        -webkit-transition: all 150ms ease;
+        transition: all 150ms ease;
+        margin-top: 10px;
+      }
+
+      button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+
+      form {
+        margin-bottom: 40px;
+        padding-bottom: 40px;
+        border-bottom: 3px solid #e6ebf1;
+      }
+
+      button:not(:disabled):hover {
+        color: #fff;
+        cursor: pointer;
+        background-color: #7795f8;
+        transform: translateY(-1px);
+        box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1),
+          0 3px 6px rgba(0, 0, 0, 0.08);
+      }
+
+      input,
+      .StripeElement {
+        display: block;
+        margin: 10px 0 20px 0;
+        max-width: 500px;
+        padding: 10px 14px;
+        font-size: 1em;
+        font-family: 'Source Code Pro', monospace;
+        box-shadow: rgba(50, 50, 93, 0.14902) 0px 1px 3px,
+          rgba(0, 0, 0, 0.0196078) 0px 1px 0px;
+        border: 0;
+        outline: 0;
+        border-radius: 4px;
+        background: white;
+      }
+
+      input::placeholder {
+        color: #aab7c4;
+      }
+
+      input:focus,
+      .StripeElement--focus {
+        box-shadow: rgba(50, 50, 93, 0.109804) 0px 4px 6px,
+          rgba(0, 0, 0, 0.0784314) 0px 1px 3px;
+        -webkit-transition: all 150ms ease;
+        transition: all 150ms ease;
+      }
+
+      .StripeElement.IdealBankElement,
+      .StripeElement.PaymentRequestButton {
+        padding: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="App"></div>
+    <script src="/paymentIntents.js"></script>
+  </body>
+</html>

--- a/demo/paymentIntents/index.js
+++ b/demo/paymentIntents/index.js
@@ -1,0 +1,256 @@
+// @flow
+/* eslint-disable no-console, react/no-multi-comp */
+import React from 'react';
+import {render} from 'react-dom';
+
+import type {InjectedProps} from '../../src/components/inject';
+
+import {
+  CardElement,
+  StripeProvider,
+  Elements,
+  injectStripe,
+} from '../../src/index';
+
+import api from './api';
+
+const handleBlur = () => {
+  console.log('[blur]');
+};
+const handleChange = (change) => {
+  console.log('[change]', change);
+};
+const handleFocus = () => {
+  console.log('[focus]');
+};
+const handleReady = () => {
+  console.log('[ready]');
+};
+
+const createOptions = (fontSize: string, padding: ?string) => {
+  return {
+    style: {
+      base: {
+        fontSize,
+        color: '#424770',
+        letterSpacing: '0.025em',
+        fontFamily: 'Source Code Pro, monospace',
+        '::placeholder': {
+          color: '#aab7c4',
+        },
+        ...(padding ? {padding} : {}),
+      },
+      invalid: {
+        color: '#9e2146',
+      },
+    },
+  };
+};
+
+class _CreatePaymentMethod extends React.Component<
+  InjectedProps & {fontSize: string},
+  {
+    error: string | null,
+    processing: boolean,
+    message: string | null,
+  }
+> {
+  state = {
+    error: null,
+    processing: false,
+    message: null,
+  };
+
+  handleSubmit = (ev) => {
+    ev.preventDefault();
+    if (this.props.stripe) {
+      this.props.stripe.createPaymentMethod().then((payload) => {
+        if (payload.error) {
+          this.setState({
+            error: `Failed to create PaymentMethod: ${payload.error.message}`,
+            processing: false,
+          });
+          console.log('[error]', payload.error);
+        } else {
+          this.setState({
+            message: `Created PaymentMethod: ${payload.paymentMethod.id}`,
+            processing: false,
+          });
+          console.log('[paymentMethod]', payload.paymentMethod);
+        }
+      });
+      this.setState({processing: true});
+    } else {
+      console.log("Stripe.js hasn't loaded yet.");
+    }
+  };
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <label>
+          stripe.createPaymentMethod
+          <CardElement
+            onBlur={handleBlur}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onReady={handleReady}
+            {...createOptions(this.props.fontSize)}
+          />
+        </label>
+        {this.state.error && <div className="error">{this.state.error}</div>}
+        {this.state.message && (
+          <div className="message">{this.state.message}</div>
+        )}
+        <button disabled={this.state.processing}>
+          {this.state.processing ? 'Processing…' : 'Pay'}
+        </button>
+      </form>
+    );
+  }
+}
+
+const CreatePaymentMethod = injectStripe(_CreatePaymentMethod);
+
+class _HandleCardPayment extends React.Component<
+  InjectedProps & {fontSize: string},
+  {
+    clientSecret: string | null,
+    error: string | null,
+    disabled: boolean,
+    succeeded: boolean,
+    processing: boolean,
+    message: string | null,
+  }
+> {
+  state = {
+    clientSecret: null,
+    error: null,
+    disabled: true,
+    succeeded: false,
+    processing: false,
+    message: null,
+  };
+
+  componentDidMount() {
+    api
+      .createPaymentIntent({
+        amount: 1099,
+        currency: 'usd',
+        payment_method_types: ['card'],
+      })
+      .then((clientSecret) => {
+        this.setState({clientSecret, disabled: false});
+      })
+      .catch((err) => {
+        this.setState({error: err.message});
+      });
+  }
+
+  handleSubmit = (ev) => {
+    ev.preventDefault();
+    if (this.props.stripe) {
+      this.props.stripe
+        .handleCardPayment(this.state.clientSecret)
+        .then((payload) => {
+          if (payload.error) {
+            this.setState({
+              error: `Charge failed: ${payload.error.message}`,
+              disabled: false,
+            });
+            console.log('[error]', payload.error);
+          } else {
+            this.setState({
+              succeeded: true,
+              message: `Charge succeeded! Payment intent is in state: ${
+                payload.paymentIntent.status
+              }`,
+            });
+            console.log('[paymentIntent]', payload.paymentIntent);
+          }
+        });
+      this.setState({disabled: true, processing: true});
+    } else {
+      console.log("Stripe.js hasn't loaded yet.");
+    }
+  };
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <label>
+          stripe.handleCardPayment
+          <CardElement
+            onBlur={handleBlur}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onReady={handleReady}
+            {...createOptions(this.props.fontSize)}
+          />
+        </label>
+        {this.state.error && <div className="error">{this.state.error}</div>}
+        {this.state.message && (
+          <div className="message">{this.state.message}</div>
+        )}
+        {!this.state.succeeded && (
+          <button disabled={this.state.disabled}>
+            {this.state.processing ? 'Processing…' : 'Pay'}
+          </button>
+        )}
+      </form>
+    );
+  }
+}
+
+const HandleCardPayment = injectStripe(_HandleCardPayment);
+
+class Checkout extends React.Component<{}, {elementFontSize: string}> {
+  constructor() {
+    super();
+    this.state = {
+      elementFontSize: window.innerWidth < 450 ? '14px' : '18px',
+    };
+    window.addEventListener('resize', () => {
+      if (window.innerWidth < 450 && this.state.elementFontSize !== '14px') {
+        this.setState({elementFontSize: '14px'});
+      } else if (
+        window.innerWidth >= 450 &&
+        this.state.elementFontSize !== '18px'
+      ) {
+        this.setState({elementFontSize: '18px'});
+      }
+    });
+  }
+
+  render() {
+    const {elementFontSize} = this.state;
+    return (
+      <div className="Checkout">
+        <h1>React Stripe Elements with PaymentIntents</h1>
+        <Elements>
+          <CreatePaymentMethod fontSize={elementFontSize} />
+        </Elements>
+        <Elements>
+          <HandleCardPayment fontSize={elementFontSize} />
+        </Elements>
+      </div>
+    );
+  }
+}
+
+const App = () => {
+  return (
+    <StripeProvider apiKey="pk_test_dCyfhfyeO2CZkcvT5xyIDdJj">
+      <Checkout />
+    </StripeProvider>
+  );
+};
+
+const appElement = document.querySelector('.App');
+if (appElement) {
+  render(<App />, appElement);
+} else {
+  console.error(
+    'We could not find an HTML element with a class name of "App" in the DOM. Please make sure you copy index.html as well for this demo to work.'
+  );
+}

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -26,7 +26,11 @@ const capitalized = (str: string) => {
 
 const Element = (
   type: string,
-  hocOptions: {impliedTokenType?: string, impliedSourceType?: string} = {}
+  hocOptions: {
+    impliedTokenType?: string,
+    impliedSourceType?: string,
+    impliedPaymentMethodType?: string,
+  } = {}
 ) =>
   class extends React.Component<Props> {
     static propTypes = {
@@ -70,12 +74,17 @@ const Element = (
 
         element.mount(this._ref);
 
-        // Register Element for automatic token / source creation
-        if (hocOptions.impliedTokenType || hocOptions.impliedSourceType) {
+        // Register Element for automatic token / source / paymentMethod creation
+        if (
+          hocOptions.impliedTokenType ||
+          hocOptions.impliedSourceType ||
+          hocOptions.impliedPaymentMethodType
+        ) {
           this.context.registerElement(
             element,
             hocOptions.impliedTokenType,
-            hocOptions.impliedSourceType
+            hocOptions.impliedSourceType,
+            hocOptions.impliedPaymentMethodType
           );
         }
       });

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -34,6 +34,7 @@ describe('Element', () => {
     const CardElement = Element('card', {
       impliedTokenType: 'card',
       impliedSourceType: 'card',
+      impliedPaymentMethodType: 'card',
     });
     const element = shallow(<CardElement id={id} />, {context});
     expect(element.find('#my-id').length).toBe(1);
@@ -44,6 +45,7 @@ describe('Element', () => {
     const CardElement = Element('card', {
       impliedTokenType: 'card',
       impliedSourceType: 'card',
+      impliedPaymentMethodType: 'card',
     });
     const element = shallow(<CardElement className={className} />, {context});
     expect(element.first().hasClass(className)).toBeTruthy();
@@ -53,6 +55,7 @@ describe('Element', () => {
     const TestElement = Element('test', {
       impliedTokenType: 'foo',
       impliedSourceType: 'bar',
+      impliedPaymentMethodType: 'baz',
     });
     const element = mount(<TestElement onChange={jest.fn()} />, {context});
 
@@ -60,7 +63,8 @@ describe('Element', () => {
     expect(context.registerElement).toHaveBeenCalledWith(
       elementMock,
       'foo',
-      'bar'
+      'bar',
+      'baz'
     );
 
     element.unmount();
@@ -85,6 +89,7 @@ describe('Element', () => {
     const CardElement = Element('card', {
       impliedTokenType: 'card',
       impliedSourceType: 'card',
+      impliedPaymentMethodType: 'card',
     });
     const onReadyMock = jest.fn();
 
@@ -105,6 +110,7 @@ describe('Element', () => {
     const TestElement = Element('test', {
       impliedTokenType: 'foo',
       impliedSourceType: 'bar',
+      impliedPaymentMethodType: 'card',
     });
     const element = mount(<TestElement onChange={jest.fn()} style={style} />, {
       context,
@@ -132,6 +138,7 @@ describe('Element', () => {
     const CardElement = Element('card', {
       impliedTokenType: 'card',
       impliedSourceType: 'card',
+      impliedPaymentMethodType: 'card',
     });
     const element = shallow(<CardElement placeholder={placeholder} />, {
       context,

--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -7,6 +7,7 @@ export type ElementsList = Array<{
   element: ElementShape,
   impliedTokenType?: string,
   impliedSourceType?: string,
+  impliedPaymentMethodType?: string,
 }>;
 export type ElementsLoadListener = (ElementsShape) => void;
 
@@ -31,7 +32,8 @@ export type ElementContext = {
   registerElement: (
     element: ElementShape,
     impliedTokenType: ?string,
-    impliedSourceType: ?string
+    impliedSourceType: ?string,
+    impliedPaymentMethodType: ?string
   ) => void,
   unregisterElement: (element: ElementShape) => void,
 };
@@ -98,7 +100,8 @@ export default class Elements extends React.Component<Props, State> {
   handleRegisterElement = (
     element: Object,
     impliedTokenType: ?string,
-    impliedSourceType: ?string
+    impliedSourceType: ?string,
+    impliedPaymentMethodType: ?string
   ) => {
     this.setState((prevState) => ({
       registeredElements: [
@@ -107,6 +110,7 @@ export default class Elements extends React.Component<Props, State> {
           element,
           ...(impliedTokenType ? {impliedTokenType} : {}),
           ...(impliedSourceType ? {impliedSourceType} : {}),
+          ...(impliedPaymentMethodType ? {impliedPaymentMethodType} : {}),
         },
       ],
     }));

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -18,6 +18,7 @@ describe('Elements', () => {
         .mockReturnValueOnce(true),
       createToken: jest.fn(),
       createSource: jest.fn(),
+      createPaymentMethod: jest.fn(),
     };
   });
 

--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -51,7 +51,14 @@ const getOrCreateStripe = (apiKey: string, options: mixed): StripeShape => {
 };
 
 const ensureStripeShape = (stripe: mixed): StripeShape => {
-  if (stripe && stripe.elements && stripe.createSource && stripe.createToken) {
+  if (
+    stripe &&
+    stripe.elements &&
+    stripe.createSource &&
+    stripe.createToken &&
+    stripe.createPaymentMethod &&
+    stripe.handleCardPayment
+  ) {
     return ((stripe: any): StripeShape);
   } else {
     throw new Error(

--- a/src/components/Provider.test.js
+++ b/src/components/Provider.test.js
@@ -13,6 +13,8 @@ describe('StripeProvider', () => {
       elements: jest.fn(),
       createToken: jest.fn(),
       createSource: jest.fn(),
+      createPaymentMethod: jest.fn(),
+      handleCardPayment: jest.fn(),
     };
     stripeMockFn = jest.fn().mockReturnValue(stripeMockResult);
     window.Stripe = stripeMockFn;

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -9,18 +9,30 @@ describe('injectStripe()', () => {
   let context;
   let createSource;
   let createToken;
+  let createPaymentMethod;
+  let handleCardPayment;
   let elementMock;
+  let rawElementMock;
 
   // Before ALL tests (sync or async)
   beforeEach(() => {
     createSource = jest.fn();
     createToken = jest.fn();
+    createPaymentMethod = jest.fn();
+    handleCardPayment = jest.fn();
+    rawElementMock = {
+      _frame: {
+        id: 'id',
+      },
+      _componentName: 'name',
+    };
     elementMock = {
       element: {
         on: jest.fn(),
       },
       impliedTokenType: 'card',
       impliedSourceType: 'card',
+      impliedPaymentMethodType: 'card',
     };
     WrappedComponent = () => <div />;
     WrappedComponent.displayName = 'WrappedComponent';
@@ -35,6 +47,8 @@ describe('injectStripe()', () => {
           elements: jest.fn(),
           createSource,
           createToken,
+          createPaymentMethod,
+          handleCardPayment,
         },
         getRegisteredElements: () => [elementMock],
       };
@@ -95,6 +109,8 @@ describe('injectStripe()', () => {
       expect(props).toHaveProperty('stripe');
       expect(props).toHaveProperty('stripe.createSource');
       expect(props).toHaveProperty('stripe.createToken');
+      expect(props).toHaveProperty('stripe.createPaymentMethod');
+      expect(props).toHaveProperty('stripe.handleCardPayment');
     });
 
     it('props.stripe.createToken calls createToken with element and empty options when called with no arguments', () => {
@@ -260,6 +276,155 @@ describe('injectStripe()', () => {
       );
     });
 
+    it('props.stripe.createPaymentMethod calls createPaymentMethod with element and type when only type is passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createPaymentMethod('card');
+      expect(createPaymentMethod).toHaveBeenCalledWith(
+        'card',
+        elementMock.element
+      );
+    });
+
+    it('props.stripe.createPaymentMethod calls createPaymentMethod with data options', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createPaymentMethod('card', {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+      expect(createPaymentMethod).toHaveBeenCalledWith(
+        'card',
+        elementMock.element,
+        {
+          billing_details: {
+            name: 'Jenny Rosen',
+          },
+        }
+      );
+    });
+
+    it('props.stripe.createPaymentMethod calls createPaymentMethod with element from arguments when passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createPaymentMethod('card', rawElementMock);
+      expect(createPaymentMethod).toHaveBeenCalledWith('card', rawElementMock);
+    });
+
+    it('props.stripe.createPaymentMethod calls createPaymentMethod with element and options from arguments when passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.createPaymentMethod('card', rawElementMock, {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+      expect(createPaymentMethod).toHaveBeenCalledWith('card', rawElementMock, {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+    });
+
+    it('props.stripe.handleCardPayment calls handleCardPayment with element and clientSecret when only clientSecret is passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.handleCardPayment('clientSecret');
+      expect(handleCardPayment).toHaveBeenCalledWith(
+        'clientSecret',
+        elementMock.element
+      );
+    });
+
+    it('props.stripe.handleCardPayment calls handleCardPayment with data options', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.handleCardPayment('clientSecret', {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+      expect(handleCardPayment).toHaveBeenCalledWith(
+        'clientSecret',
+        elementMock.element,
+        {
+          billing_details: {
+            name: 'Jenny Rosen',
+          },
+        }
+      );
+    });
+
+    it('props.stripe.handleCardPayment calls handleCardPayment with element from arguments when passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.handleCardPayment('clientSecret', rawElementMock);
+      expect(handleCardPayment).toHaveBeenCalledWith(
+        'clientSecret',
+        rawElementMock
+      );
+    });
+
+    it('props.stripe.handleCardPayment calls handleCardPayment with element and data from arguments when passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.handleCardPayment('clientSecret', rawElementMock, {
+        billing_details: {
+          name: 'Jenny Rosen',
+        },
+      });
+      expect(handleCardPayment).toHaveBeenCalledWith(
+        'clientSecret',
+        rawElementMock,
+        {
+          billing_details: {
+            name: 'Jenny Rosen',
+          },
+        }
+      );
+    });
+
     it('throws when `getWrappedInstance` is called without `{withRef: true}` option.', () => {
       const Injected = injectStripe(WrappedComponent);
 
@@ -321,6 +486,8 @@ describe('injectStripe()', () => {
               elements: jest.fn(),
               createSource,
               createToken,
+              createPaymentMethod,
+              handleCardPayment,
             });
           },
           getRegisteredElements: () => [elementMock],
@@ -331,6 +498,8 @@ describe('injectStripe()', () => {
       expect(props).toHaveProperty('stripe');
       expect(props).toHaveProperty('stripe.createToken');
       expect(props).toHaveProperty('stripe.createSource');
+      expect(props).toHaveProperty('stripe.createPaymentMethod');
+      expect(props).toHaveProperty('stripe.createPaymentMethod');
     });
   });
 });

--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -25,4 +25,14 @@ declare type StripeShape = {
     type: string | ElementShape,
     options: mixed
   ) => Promise<{token?: MixedObject, error?: MixedObject}>,
+  createPaymentMethod: (
+    type: string,
+    element: ElementShape | MixedObject,
+    data: mixed
+  ) => Promise<{paymentMethod?: MixedObject, error?: MixedObject}>,
+  handleCardPayment: (
+    clientSecret: string,
+    element: ElementShape | MixedObject,
+    options: mixed
+  ) => Promise<{paymentIntent?: MixedObject, error?: MixedObject}>,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ const CardNumberElement = Element('cardNumber', {
 });
 const CardExpiryElement = Element('cardExpiry');
 const CardCVCElement = Element('cardCvc');
-const PostalCodeElement = Element('postalCode');
 
 // IBAN
 const IbanElement = Element('iban', {
@@ -42,7 +41,6 @@ export {
   CardNumberElement,
   CardExpiryElement,
   CardCVCElement,
-  PostalCodeElement,
   PaymentRequestButtonElement,
   IbanElement,
   IdealBankElement,

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import PaymentRequestButtonElement from './components/PaymentRequestButtonElemen
 const CardElement = Element('card', {
   impliedTokenType: 'card',
   impliedSourceType: 'card',
+  impliedPaymentMethodType: 'card',
 });
 
 // Split Fields
@@ -20,6 +21,7 @@ const CardElement = Element('card', {
 const CardNumberElement = Element('cardNumber', {
   impliedTokenType: 'card',
   impliedSourceType: 'card',
+  impliedPaymentMethodType: 'card',
 });
 const CardExpiryElement = Element('cardExpiry');
 const CardCVCElement = Element('cardCvc');

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,7 +10,6 @@ import {
   CardNumberElement,
   CardExpiryElement,
   CardCVCElement,
-  PostalCodeElement,
 } from './index';
 
 class PureWrapper extends React.PureComponent {
@@ -122,7 +121,6 @@ describe('index', () => {
               <CardNumberElement />
               <CardExpiryElement />
               <CardCVCElement />
-              <PostalCodeElement />
             </Checkout>
           </Elements>
         </StripeProvider>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 // @noflow
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const webpack = require('webpack');
 
 const config = {
   mode: 'development',
@@ -10,6 +11,7 @@ const config = {
   entry: {
     demo: ['./demo/demo/index.js'],
     async: ['./demo/async/main.js'],
+    paymentIntents: ['./demo/paymentIntents/index.js'],
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -25,6 +27,16 @@ const config = {
       inject: false,
       filename: 'async/index.html',
       template: './demo/async/index.html',
+    }),
+    new HtmlWebpackPlugin({
+      inject: false,
+      filename: 'paymentIntents/index.html',
+      template: './demo/paymentIntents/index.html',
+    }),
+    new webpack.DefinePlugin({
+      'process.env.STRIPE_SECRET_KEY': JSON.stringify(
+        process.env.STRIPE_SECRET_KEY
+      ),
     }),
   ],
 };


### PR DESCRIPTION
# 3.0.0
### New Features
- added support for `stripe.handleCardPayment` and `stripe.createPaymentMethod`. These methods allow you to easily integrate Stripe's new Payment Intents API. Like `createToken` and `createSource`, these new methods will automatically find and use a corresponding Element when they are called.
  - ```js
    stripe.createPaymentMethod(
      paymentMethodType: string, 
      paymentMethodDetails: Object
    ): Promise<{error?: Object, paymentIntent?: Object}>

    stripe.handleCardPayment(
      clientSecret: string, 
      paymentMethodDetails: Object
    ): Promise<{error?: Object, paymentIntent?: Object}>
    ```
  - Stripe.js Reference
    - [`stripe.createPaymentMethod`](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method)
    - [`stripe.handleCardPayment`](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment)
  - [Payment Intents API](https://stripe.com/docs/payments/payment-intents)
  - [Payment Methods API](https://stripe.com/docs/payments/payment-methods)
### Breaking Changes:
- If you were already using `handleCardPayment` or `createPaymentMethod` with `react-stripe-elements`, you should upgrade your integration. These methods will now automatically find and use valid Elements.
- Beta versions of Payment Intents with Stripe.js are not supported.
- `PostalCodeElement` has been removed. Users are suggested to build their own postal code input.