### PR TITLE
Allow trying example in Online Dev Environment via Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 8080
+  onOpen: open-preview
+tasks:
+- init: yarn install
+  command: yarn run demo


### PR DESCRIPTION
### Summary & motivation

I came across this tweet [this tweet](https://twitter.com/athyuttamre/status/1121892995744161793) expressing the interest in a powerful online editor with support for native tools and demo environment.

That's exactly what gitpod.io does. 

This PR adds a small config file so that when a Gitpod workspace is opened on this repo, `yarn install` and `yarn run demo` is executed. Also, the config exposes port `8080` so that your running web application can be shown in the web browser or Gitpod's preview. The result can be seen in the screenshot below.

To try it, click on this link:
https://gitpod.io/#https://github.com/meysholdt/react-stripe-elements

This will:
* launch a new dev environment (based on docker) on the gitpod.io servers
* clone the git repo (GitHub OAuth needed)
* run `yarn install` in the Gitpod IDE in the Terminal
* run `yarn run demo` in the Gitpod IDE in the Terminal
* Open the react-stripe-elements web app in the Preview view. See the screenshot to see how this looks like. 

Disclaimer: I'm a co-founder of Gitpod.

![image](https://user-images.githubusercontent.com/239422/56845678-1e6fcc00-68c5-11e9-93b5-7f22515f7d93.png)
