### PR TITLE
[Demo] Move intent creation to Runkit.

### DIFF
--- a/demo/intents/api.js
+++ b/demo/intents/api.js
@@ -1,52 +1,15 @@
 // @flow
 
-const {STRIPE_SECRET_KEY} = process.env;
-
-const serialize = (object: Object, scope: ?string): string => {
-  let result = [];
-  Object.keys(object).forEach((key) => {
-    const value = object[key];
-    const scopedKey = scope ? `${scope}[${key}]` : key;
-    if (value && typeof value === 'object') {
-      const nestedResult = serialize(value, scopedKey);
-      if (nestedResult !== '') {
-        result = [...result, nestedResult];
-      }
-    } else if (value !== undefined && value !== null) {
-      result = [...result, `${scopedKey}=${encodeURIComponent(String(value))}`];
-    }
-  });
-  return result.join('&').replace(/%20/g, '+');
-};
-
 const createPaymentIntent = (options: {}): Promise<string> => {
-  if (!STRIPE_SECRET_KEY) {
-    return Promise.reject(
-      new Error(
-        `A secret key is required to create PaymentIntents for handleCardPayment. Please set the following environment variable: \n\nSTRIPE_SECRET_KEY=<your secret key> \n\nSTRIPE_PUBLISHABLE_KEY=<your publishable key>`
-      )
-    );
-  }
-
-  // WARNING
-  // DO NOT USE THE FOLLOWING CODE IN A PRODUCTION APPLICATION!
-  // Your secret key should NEVER be used in on your frontend.
-  // We are doing this here purely for demonstration reasons.
-  // In the real world, creating PaymentIntents needs to be done
-  // on your backend server.
-  //
-  // Including your secret key on your frontend enables others
-  // to make charges on your behalf. Fraudsters will find your
-  // secret key and use it to test stolen card numbers, which will
-  // get your business banned from accepting credit card payments.
+  // To use this demo with your own Stripe account, clone this Runkit backend:
+  // https://runkit.com/stripe/create-intents
   return window
-    .fetch(`https://api.stripe.com/v1/payment_intents`, {
+    .fetch(`https://create-intents-35aylzrcx0ej.runkit.sh/payment_intents`, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/json',
       },
-      body: serialize(options),
+      body: JSON.stringify({options}),
     })
     .then((res) => {
       if (res.status === 200) {
@@ -66,33 +29,15 @@ const createPaymentIntent = (options: {}): Promise<string> => {
 };
 
 const createSetupIntent = (options: {}): Promise<string> => {
-  if (!STRIPE_SECRET_KEY) {
-    return Promise.reject(
-      new Error(
-        `A secret key is required to create StupIntents for handleCardSetup. Please set the following environment variables: \n\nSTRIPE_SECRET_KEY=<your secret key> \n\nSTRIPE_PUBLISHABLE_KEY=<your publishable key>`
-      )
-    );
-  }
-
-  // WARNING
-  // DO NOT USE THE FOLLOWING CODE IN A PRODUCTION APPLICATION!
-  // Your secret key should NEVER be used in on your frontend.
-  // We are doing this here purely for demonstration reasons.
-  // In the real world, creating StupIntents needs to be done
-  // on your backend server.
-  //
-  // Including your secret key on your frontend enables others
-  // to make charges on your behalf. Fraudsters will find your
-  // secret key and use it to test stolen card numbers, which will
-  // get your business banned from accepting credit card payments.
+  // To use this demo with your own Stripe account, clone this Runkit backend:
+  // https://runkit.com/stripe/create-intents
   return window
-    .fetch(`https://api.stripe.com/v1/setup_intents`, {
+    .fetch(`https://create-intents-35aylzrcx0ej.runkit.sh/setup_intents`, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/json',
       },
-      body: serialize(options),
+      body: JSON.stringify({options}),
     })
     .then((res) => {
       if (res.status === 200) {

--- a/demo/intents/index.js
+++ b/demo/intents/index.js
@@ -14,8 +14,6 @@ import {
 
 import api from './api';
 
-const {STRIPE_PUBLISHABLE_KEY} = process.env;
-
 const handleBlur = () => {
   console.log('[blur]');
 };
@@ -105,7 +103,7 @@ class _CreatePaymentMethod extends React.Component<
           <div className="message">{this.state.message}</div>
         )}
         <button disabled={this.state.processing}>
-          {this.state.processing ? 'Processing…' : 'Pay'}
+          {this.state.processing ? 'Processing…' : 'Create'}
         </button>
       </form>
     );
@@ -286,7 +284,7 @@ class _HandleCardSetup extends React.Component<
         )}
         {!this.state.succeeded && (
           <button disabled={this.state.disabled}>
-            {this.state.processing ? 'Processing…' : 'Pay'}
+            {this.state.processing ? 'Processing…' : 'Setup'}
           </button>
         )}
       </form>
@@ -335,9 +333,7 @@ class Checkout extends React.Component<{}, {elementFontSize: string}> {
 
 const App = () => {
   return (
-    <StripeProvider
-      apiKey={STRIPE_PUBLISHABLE_KEY || 'pk_test_dCyfhfyeO2CZkcvT5xyIDdJj'}
-    >
+    <StripeProvider apiKey="pk_test_6pRNASCoBOKtIshFeQd4XMUh">
       <Checkout />
     </StripeProvider>
   );

--- a/demo/intents/index.js
+++ b/demo/intents/index.js
@@ -64,7 +64,7 @@ class _CreatePaymentMethod extends React.Component<
   handleSubmit = (ev) => {
     ev.preventDefault();
     if (this.props.stripe) {
-      this.props.stripe.createPaymentMethod().then((payload) => {
+      this.props.stripe.createPaymentMethod('card').then((payload) => {
         if (payload.error) {
           this.setState({
             error: `Failed to create PaymentMethod: ${payload.error.message}`,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,14 +33,6 @@ const config = {
       filename: 'intents/index.html',
       template: './demo/intents/index.html',
     }),
-    new webpack.DefinePlugin({
-      'process.env.STRIPE_SECRET_KEY': JSON.stringify(
-        process.env.STRIPE_SECRET_KEY
-      ),
-      'process.env.STRIPE_PUBLISHABLE_KEY': JSON.stringify(
-        process.env.STRIPE_PUBLISHABLE_KEY
-      ),
-    }),
   ],
 };
 


### PR DESCRIPTION
### Summary & motivation
* Move the PaymentIntent and SetupIntent creation to Runkit instead of creating them client-side.
* Use default docs site keys as the other demos do.
* Update the button text in the intents demo:
![image](https://user-images.githubusercontent.com/23213994/62557450-ea665880-b86e-11e9-93ba-1e36809ffa9c.png)


### Testing & documentation
`npm run demo`
http://localhost:8080/intents