### PR TITLE
Allow handleCard* with only the client secret

### DIFF
--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -284,7 +284,7 @@ Please be sure the component that calls createSource or createToken is within an
     wrappedHandleCardX = (
       stripe: StripeShape,
       method: 'handleCardPayment' | 'handleCardSetup'
-    ) => (clientSecret: mixed, elementOrData?: mixed, maybeData?: mixed) => {
+    ) => (clientSecret: mixed, elementOrData: mixed, maybeData: mixed) => {
       if (!clientSecret || typeof clientSecret !== 'string') {
         // If a bad value was passed in for clientSecret, throw an error.
         throw new Error(
@@ -321,20 +321,12 @@ Please be sure the component that calls createSource or createToken is within an
         } else {
           return stripe[method](clientSecret, element);
         }
-      } else {
-        if (!data) {
-          throw new Error(
-            `Could not find a CardElement or CardNumberElement which which to perform handleCardPayment.`
-          );
-        } else if (typeof data !== 'object') {
-          throw new Error(
-            `Invalid data passed to handleCardPayment. Expected an object, got ${typeof data}.`
-          );
-        }
-
-        // If no Element exists that can create a card PaymentMethod,
-        // directly call handleCard*.
+      } else if (data) {
+        // if no element exists call handleCard* directly (with data)
         return stripe[method](clientSecret, data);
+      } else {
+        // if no element exists call handleCard* directly (with only the clientSecret)
+        return stripe[method](clientSecret);
       }
     };
 

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -428,6 +428,20 @@ describe('injectStripe()', () => {
       );
     });
 
+    it('props.stripe.handleCardPayment calls handleCardPayment with only the clientSecret when no element is present', () => {
+      context.getRegisteredElements = () => [];
+
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.handleCardPayment('clientSecret');
+      expect(handleCardPayment).toHaveBeenCalledWith('clientSecret');
+    });
+
     it('props.stripe.handleCardSetup calls handleCardSetup with element and clientSecret when only clientSecret is passed in', () => {
       const Injected = injectStripe(WrappedComponent);
 
@@ -504,6 +518,20 @@ describe('injectStripe()', () => {
           },
         }
       );
+    });
+
+    it('props.stripe.handleCardSetup calls handleCardSetup with only the clientSecret when no element is present', () => {
+      context.getRegisteredElements = () => [];
+
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      props.stripe.handleCardSetup('clientSecret');
+      expect(handleCardSetup).toHaveBeenCalledWith('clientSecret');
     });
 
     it('throws when `getWrappedInstance` is called without `{withRef: true}` option.', () => {

--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -32,12 +32,12 @@ declare type StripeShape = {
   ) => Promise<{paymentMethod?: MixedObject, error?: MixedObject}>,
   handleCardPayment: (
     clientSecret: string,
-    element: ElementShape | MixedObject,
+    element: mixed,
     options: mixed
   ) => Promise<{paymentIntent?: MixedObject, error?: MixedObject}>,
   handleCardSetup: (
     clientSecret: string,
-    element: ElementShape | MixedObject,
+    element: mixed,
     options: mixed
   ) => Promise<{setupIntent?: MixedObject, error?: MixedObject}>,
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -609,7 +609,7 @@ describe('index', () => {
     });
 
     describe('handleCardPayment', () => {
-      it('should throw if no Slient Secret is specified', () => {
+      it('should throw if no client secret is specified', () => {
         const Checkout = WrappedCheckout((props) =>
           props.stripe.handleCardPayment()
         );
@@ -625,21 +625,6 @@ describe('index', () => {
         );
         expect(() => app.find('form').simulate('submit')).toThrowError(
           /Invalid PaymentIntent client secret/
-        );
-      });
-      it('should throw if no card element is present and no elmenent or payment data is passed in', () => {
-        const Checkout = WrappedCheckout((props) =>
-          props.stripe.handleCardPayment('client_secret')
-        );
-        const app = mount(
-          <StripeProvider apiKey="pk_test_xxx">
-            <Elements>
-              <Checkout>Hello world</Checkout>
-            </Elements>
-          </StripeProvider>
-        );
-        expect(() => app.find('form').simulate('submit')).toThrowError(
-          /Could not find a CardElement or CardNumberElement/
         );
       });
     });


### PR DESCRIPTION
### Summary & motivation
Fixes a bug where trying to call handleCard* with an already confirmed Intent and only passing in the `client_secret` would cause `react-stripe-elements` to throw an error. This behavior is supported in Stripe.js and is the recommended integration for dealing with PaymentRequest.


### Testing & documentation
Added some new tests, removed an obsolete one.
