### PR TITLE
fix createPaymentMethod in IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 `react-stripe-elements` adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v5.0.1 - 2019-09-18
+
+### Bug Fixes
+
+- Fixes a bug where calling `stripe.createPaymentMethod` would error in IE.
+
 ## v5.0.0 - 2019-08-27
 
 ### New Features

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -232,7 +232,7 @@ Please be sure the component that calls createSource or createToken is within an
         );
       }
 
-      if (!['card'].includes(paymentMethodType)) {
+      if (['card'].indexOf(paymentMethodType) === -1) {
         throw new Error(
           `Invalid PaymentMethod type passed to createPaymentMethod. ${paymentMethodType} is not yet supported.`
         );

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -294,6 +294,19 @@ describe('injectStripe()', () => {
       );
     });
 
+    it('props.stripe.createPaymentMethod errors when an invalid type is passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      expect(() => props.stripe.createPaymentMethod('ideal')).toThrow(
+        `Invalid PaymentMethod type passed to createPaymentMethod. ideal is not yet supported.`
+      );
+    });
+
     it('props.stripe.createPaymentMethod calls createPaymentMethod with data options', () => {
       const Injected = injectStripe(WrappedComponent);
 


### PR DESCRIPTION
### Summary & motivation
Fixes a bug where calling `stripe.createPaymentMethod` would throw in IE.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
I wrote automated tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
