### PR TITLE
fix createPaymentMethod in ie

### DIFF
--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -230,7 +230,7 @@ Please be sure the component that calls createSource or createToken is within an
         );
       }
 
-      if (!['card'].includes(paymentMethodType)) {
+      if (['card'].indexOf(paymentMethodType) === -1) {
         throw new Error(
           `Invalid PaymentMethod type passed to createPaymentMethod. ${paymentMethodType} is not yet supported.`
         );

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -291,6 +291,19 @@ describe('injectStripe()', () => {
       );
     });
 
+    it('props.stripe.createPaymentMethod errors when an invalid type is passed in', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      expect(() => props.stripe.createPaymentMethod('ideal')).toThrow(
+        `Invalid PaymentMethod type passed to createPaymentMethod. ideal is not yet supported.`
+      );
+    });
+
     it('props.stripe.createPaymentMethod calls createPaymentMethod with data options', () => {
       const Injected = injectStripe(WrappedComponent);
 


### PR DESCRIPTION
### Summary & motivation
Fixes a bug where `stripe.createPaymentMethod` would throw in IE.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->


[this template]:
  https://github.com/stripe/react-stripe-elements/tree/master/.github/API_REVIEW.md

### Testing & documentation
I wrote unit tests.
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
