### PR TITLE
Let the API determine what payment methods are allowable

### DIFF
--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -232,12 +232,6 @@ Please be sure the component that calls createSource or createToken is within an
         );
       }
 
-      if (['card'].indexOf(paymentMethodType) === -1) {
-        throw new Error(
-          `Invalid PaymentMethod type passed to createPaymentMethod. ${paymentMethodType} is not yet supported.`
-        );
-      }
-
       const elementOrDataResult = this.parseElementOrData(elementOrData);
 
       // Second argument is Element; use passed in Element

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -294,19 +294,6 @@ describe('injectStripe()', () => {
       );
     });
 
-    it('props.stripe.createPaymentMethod errors when an invalid type is passed in', () => {
-      const Injected = injectStripe(WrappedComponent);
-
-      const wrapper = shallow(<Injected />, {
-        context,
-      });
-
-      const props = wrapper.props();
-      expect(() => props.stripe.createPaymentMethod('ideal')).toThrow(
-        `Invalid PaymentMethod type passed to createPaymentMethod. ideal is not yet supported.`
-      );
-    });
-
     it('props.stripe.createPaymentMethod calls createPaymentMethod with data options', () => {
       const Injected = injectStripe(WrappedComponent);
 


### PR DESCRIPTION
### Summary & motivation

The API already knows what payment methods can be used with `createPaymentMethod`, so we can defer to it for providing errors when using a disallowed payment method.

### Testing & documentation

Automated tests updated
