### PR TITLE
Fix crash when trying to create element while unmounting

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -67,6 +67,10 @@ const Element = (
 
     componentDidMount() {
       this.context.addElementsLoadListener((elements: ElementsShape) => {
+        if (!this._ref) {
+          return;
+        }
+
         const element = elements.create(type, this._options);
         this._element = element;
 

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -151,4 +151,24 @@ describe('Element', () => {
     const TestElement = Element('test');
     expect(TestElement.displayName).toEqual('TestElement');
   });
+
+  it('Do not create element if component is not mounted', () => {
+    const listeners = [];
+    context.addElementsLoadListener = (fn) => listeners.push(fn);
+
+    const CardElement = Element('card', {
+      impliedTokenType: 'card',
+      impliedSourceType: 'card',
+      impliedPaymentMethodType: 'card',
+    });
+    const element = mount(<CardElement />, {context});
+    element.unmount();
+
+    // ensure listener was called on mount
+    expect(listeners).toHaveLength(1);
+    // simulate load complete after unmount
+    listeners[0](elementsMock);
+    // listener should do nothing since it's unmounted
+    expect(elementsMock.create).toHaveBeenCalledTimes(0);
+  });
 });


### PR DESCRIPTION
### Summary & motivation

We just experienced React crash because this component tried to `element.mount()` with a `null` ref.
Order of events:
- React sets div ref via `handleRef`
- React calls `componentDidMount`
- `addElementsLoadListener` registers callback
- React calls `componentWillUnmount` (`element` hasn't been created so this does nothing)
- React sets ref to `null` via `handleRef`
- `addElementsLoadListener` callback is called

At this point the callback should do nothing instead of trying to create the element, which is what this PR changes.