### PR TITLE
add getElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,14 +636,14 @@ class CardSection extends React.Component {
 export default CardSection;
 ```
 
-(Note that this functionality is new as of react-stripe-elements v1.6.0.)####
-Using `onReady`
+(Note that this functionality is new as of react-stripe-elements v1.6.0.)
+
+[element]: https://stripe.com/docs/stripe-js/reference#other-methods
 
 #### Using `getElement`
 
 In addition to `onReady`, you can also access to the underlying Element by using
-a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to the access the
-component instance and calling `getElement()`.
+a [ref] to the access the component instance and calling `getElement()`.
 
 Note that if you are async loading Stripe.js, until it loads `getElement` will
 return `null`.
@@ -676,6 +676,8 @@ class CardSection extends React.Component {
 
 export default CardSection;
 ```
+
+[ref]: https://reactjs.org/docs/refs-and-the-dom.html
 
 ### `injectStripe` HOC
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ styles, fonts).
     - [Available components](#available-components)
     - [Props shape](#props-shape-2)
     - [Using `onReady`](#using-onready)
+    - [Using `getElement`](#using-getelement)
   - [`injectStripe` HOC](#injectstripe-hoc)
     - [Example](#example)
 - [Troubleshooting](#troubleshooting)
@@ -635,9 +636,46 @@ class CardSection extends React.Component {
 export default CardSection;
 ```
 
-(Note that this functionality is new as of react-stripe-elements v1.6.0.)
+(Note that this functionality is new as of react-stripe-elements v1.6.0.)####
+Using `onReady`
 
-[element]: https://stripe.com/docs/stripe-js/reference#other-methods
+#### Using `getElement`
+
+In addition to `onReady`, you can also access to the underlying Element by using
+a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to the access the
+component instance and calling `getElement()`.
+
+Note that if you are async loading Stripe.js, until it loads `getElement` will
+return `null`.
+
+```jsx
+// CardSection.js
+import React from 'react';
+import {CardElement} from 'react-stripe-elements';
+
+class CardSection extends React.Component {
+  ref = React.createRef();
+
+  focus() {
+    const element = this.ref.current.getElement();
+
+    if (element) {
+      element.focus();
+    }
+  }
+
+  render = () => {
+    return (
+      <label>
+        Card details
+        <CardElement ref={this.ref} />
+      </label>
+    );
+  };
+}
+
+export default CardSection;
+```
 
 ### `injectStripe` HOC
 

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -111,6 +111,8 @@ const Element = (
       }
     }
 
+    getElement = () => this._element;
+
     context: ElementContext;
     _element: ElementShape | null;
     _ref: ?HTMLElement;

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -151,4 +151,15 @@ describe('Element', () => {
     const TestElement = Element('test');
     expect(TestElement.displayName).toEqual('TestElement');
   });
+
+  it('should expose the underlying element instance ', () => {
+    const CardElement = Element('card');
+    const element = mount(<CardElement />, {context});
+    const rawElement = element
+      .find(CardElement)
+      .instance()
+      .getElement();
+
+    expect(rawElement).toEqual(elementMock);
+  });
 });


### PR DESCRIPTION
### Summary & motivation
Add support for accessing the underlying Element using refs. This API is a bit more obvious than the `onReady` handler, and will make it easier to document and support new Stripe.js APIs that take an Element but do not work well with RSE's element injection strategy.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
I wrote unit tests
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
