### PR TITLE
inject elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ get a refrence to an Element to use
 or
 [`createPaymentMethod()`](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method).
 
+Note that the old API for `createPaymentMethod` will continue to work and
+provide automatic element injection, but we are updating documentation and
+examples to use the new argument shape:
+
+```js
+// old shape with automatic element detection - still works
+this.props.stripe.createPaymentMethod('card').then(/* ... */);
+
+// new shape without automatic element detection - recommended and will work with new non-card PaymentMethods
+this.props.stripe
+  .createPaymentMethod({
+    type: 'card',
+    card: this.props.elements.getElement('card'),
+  })
+  .then(/* ... */);
+```
+
 ### Breaking Changes
 
 - We have removed the `getElement` method on RSE components that we introduced
@@ -74,9 +91,11 @@ or
     ): Promise<{error?: Object, setupIntent?: Object}>
   ```
 
-  For more information, please review the Stripe Docs:
+````
 
-  - [`stripe.handleCardSetup`](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup)
+For more information, please review the Stripe Docs:
+
+- [`stripe.handleCardSetup`](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup)
 
 ### Deprecations
 
@@ -388,3 +407,4 @@ Initial release! Support for:
   - CardExpiryElement
   - CardCVCElement
   - PostalCodeElement
+````

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 `react-stripe-elements` adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v6.0.0 - 2019-11-05
+
+### New Features
+
+- `injectStripe` now injects a reference to the Elements instance created by
+  `<Elements>` as the prop `elements`.
+
+The primary reason you would want an Elements instance is to use
+[`elements.getElement()`](https://stripe.com/docs/stripe-js/reference#elements-get-element).
+which provides an easy way to get a reference to an Element. You will need to
+get a refrence to an Element to use
+[`confirmCardPayment`](https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-payment),
+[`confirmCardSetup()`](https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-setup),
+or
+[`createPaymentMethod()`](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method).
+
+### Breaking Changes
+
+- We have removed the `getElement` method on RSE components that we introduced
+  in v5.1.0 in favor of the above change. Sorry for the churn.
+
 ## v5.1.0 - 2019-10-22
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -726,8 +726,9 @@ Within the wrapped component, the `stripe` and `elements` props have the type:
 type FactoryProps = {
   elements: null | {
     getElement: (type: string) => Element | null,
-    // and other functions available on the `elements` object,
-    // as officially documented here: https://stripe.com/docs/elements/reference#the-elements-object
+    // For more detail and documentation on other methods available on
+    // the `elements` object, please refer to our official documentation:
+    // https://stripe.com/docs/elements/reference#the-elements-object
   },
   stripe: null | {
     createToken: (tokenData: {type?: string}) => Promise<{
@@ -744,22 +745,23 @@ type FactoryProps = {
       paymentMethod?: Object,
       error?: Object,
     }>,
-    handleCardPayment: (
+    confirmCardPayment: (
       clientSecret: string,
-      paymentMethodData?: Object
+      paymentIntentData?: Object
     ) => Promise<{
       paymentIntent?: Object,
       error?: Object,
     }>,
-    handleCardSetup: (
+    confirmCardSetup: (
       clientSecret: string,
-      paymentMethodData?: Object
+      paymentIntentData?: Object
     ) => Promise<{
       setupIntent?: Object,
       error?: Object,
     }>,
-    // and other functions available on the `stripe` object,
-    // as officially documented here: https://stripe.com/docs/elements/reference#the-stripe-object
+    // For more detail and documentation on other methods available on
+    // the `stripe` object, please refer to our official documentation:
+    // https://stripe.com/docs/elements/reference#the-stripe-object
   },
 };
 ```
@@ -811,9 +813,14 @@ reach all components.
 2.  You can use the [`pure: false`][pure-false] option for redux-connect:
 
     ```jsx
-    const Component = connect(mapStateToProps, mapDispatchToProps, mergeProps, {
-      pure: false,
-    })(injectStripe(_CardForm));
+    const Component = connect(
+      mapStateToProps,
+      mapDispatchToProps,
+      mergeProps,
+      {
+        pure: false,
+      }
+    )(injectStripe(_CardForm));
     ```
 
 [pure-false]:

--- a/demo/intents/index.js
+++ b/demo/intents/index.js
@@ -63,22 +63,27 @@ class _CreatePaymentMethod extends React.Component<
 
   handleSubmit = (ev) => {
     ev.preventDefault();
-    if (this.props.stripe) {
-      this.props.stripe.createPaymentMethod('card').then((payload) => {
-        if (payload.error) {
-          this.setState({
-            error: `Failed to create PaymentMethod: ${payload.error.message}`,
-            processing: false,
-          });
-          console.log('[error]', payload.error);
-        } else {
-          this.setState({
-            message: `Created PaymentMethod: ${payload.paymentMethod.id}`,
-            processing: false,
-          });
-          console.log('[paymentMethod]', payload.paymentMethod);
-        }
-      });
+    if (this.props.stripe && this.props.elements) {
+      this.props.stripe
+        .createPaymentMethod({
+          type: 'card',
+          card: this.props.elements.getElement('card'),
+        })
+        .then((payload) => {
+          if (payload.error) {
+            this.setState({
+              error: `Failed to create PaymentMethod: ${payload.error.message}`,
+              processing: false,
+            });
+            console.log('[error]', payload.error);
+          } else {
+            this.setState({
+              message: `Created PaymentMethod: ${payload.paymentMethod.id}`,
+              processing: false,
+            });
+            console.log('[paymentMethod]', payload.paymentMethod);
+          }
+        });
       this.setState({processing: true});
     } else {
       console.log("Stripe.js hasn't loaded yet.");
@@ -149,9 +154,13 @@ class _HandleCardPayment extends React.Component<
 
   handleSubmit = (ev) => {
     ev.preventDefault();
-    if (this.props.stripe) {
+    if (this.props.stripe && this.props.elements) {
       this.props.stripe
-        .handleCardPayment(this.state.clientSecret)
+        .confirmCardPayment(this.state.clientSecret, {
+          payment_method: {
+            card: this.props.elements.getElement('card'),
+          },
+        })
         .then((payload) => {
           if (payload.error) {
             this.setState({
@@ -162,9 +171,7 @@ class _HandleCardPayment extends React.Component<
           } else {
             this.setState({
               succeeded: true,
-              message: `Charge succeeded! PaymentIntent is in state: ${
-                payload.paymentIntent.status
-              }`,
+              message: `Charge succeeded! PaymentIntent is in state: ${payload.paymentIntent.status}`,
             });
             console.log('[PaymentIntent]', payload.paymentIntent);
           }
@@ -179,7 +186,7 @@ class _HandleCardPayment extends React.Component<
     return (
       <form onSubmit={this.handleSubmit}>
         <label>
-          stripe.handleCardPayment
+          stripe.confirmCardPayment
           <CardElement
             onBlur={handleBlur}
             onChange={handleChange}
@@ -239,9 +246,13 @@ class _HandleCardSetup extends React.Component<
 
   handleSubmit = (ev) => {
     ev.preventDefault();
-    if (this.props.stripe) {
+    if (this.props.stripe && this.props.elements) {
       this.props.stripe
-        .handleCardSetup(this.state.clientSecret)
+        .confirmCardSetup(this.state.clientSecret, {
+          payment_method: {
+            card: this.props.elements.getElement('card'),
+          },
+        })
         .then((payload) => {
           if (payload.error) {
             this.setState({
@@ -252,9 +263,7 @@ class _HandleCardSetup extends React.Component<
           } else {
             this.setState({
               succeeded: true,
-              message: `Setup succeeded! SetupIntent is in state: ${
-                payload.setupIntent.status
-              }`,
+              message: `Setup succeeded! SetupIntent is in state: ${payload.setupIntent.status}`,
             });
             console.log('[SetupIntent]', payload.setupIntent);
           }
@@ -269,7 +278,7 @@ class _HandleCardSetup extends React.Component<
     return (
       <form onSubmit={this.handleSubmit}>
         <label>
-          stripe.handleCardSetup
+          stripe.confirmCardSetup
           <CardElement
             onBlur={handleBlur}
             onChange={handleChange}

--- a/demo/intents/index.js
+++ b/demo/intents/index.js
@@ -171,7 +171,9 @@ class _HandleCardPayment extends React.Component<
           } else {
             this.setState({
               succeeded: true,
-              message: `Charge succeeded! PaymentIntent is in state: ${payload.paymentIntent.status}`,
+              message: `Charge succeeded! PaymentIntent is in state: ${
+                payload.paymentIntent.status
+              }`,
             });
             console.log('[PaymentIntent]', payload.paymentIntent);
           }
@@ -263,7 +265,9 @@ class _HandleCardSetup extends React.Component<
           } else {
             this.setState({
               succeeded: true,
-              message: `Setup succeeded! SetupIntent is in state: ${payload.setupIntent.status}`,
+              message: `Setup succeeded! SetupIntent is in state: ${
+                payload.setupIntent.status
+              }`,
             });
             console.log('[SetupIntent]', payload.setupIntent);
           }

--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -115,8 +115,6 @@ const Element = (
       }
     }
 
-    getElement = () => this._element;
-
     context: ElementContext;
     _element: ElementShape | null;
     _ref: ?HTMLElement;

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -171,15 +171,4 @@ describe('Element', () => {
     // listener should do nothing since it's unmounted
     expect(elementsMock.create).toHaveBeenCalledTimes(0);
   });
-
-  it('should expose the underlying element instance ', () => {
-    const CardElement = Element('card');
-    const element = mount(<CardElement />, {context});
-    const rawElement = element
-      .find(CardElement)
-      .instance()
-      .getElement();
-
-    expect(rawElement).toEqual(elementMock);
-  });
 });

--- a/src/components/Elements.test.js
+++ b/src/components/Elements.test.js
@@ -6,6 +6,7 @@ import Elements from './Elements';
 
 describe('Elements', () => {
   let stripeMock;
+  const elementsMock = {};
 
   beforeEach(() => {
     stripeMock = {
@@ -15,7 +16,7 @@ describe('Elements', () => {
             'elements() should not be called twice in this test.'
           );
         })
-        .mockReturnValueOnce(true),
+        .mockReturnValueOnce(elementsMock),
       createToken: jest.fn(),
       createSource: jest.fn(),
       createPaymentMethod: jest.fn(),
@@ -39,6 +40,7 @@ describe('Elements', () => {
       'registerElement',
       'unregisterElement',
       'getRegisteredElements',
+      'elements',
     ]);
   });
 
@@ -58,10 +60,26 @@ describe('Elements', () => {
     const mockCallback = jest.fn();
     childContext.addElementsLoadListener(mockCallback);
     expect(mockCallback).toHaveBeenCalledTimes(1);
-    expect(mockCallback).toHaveBeenLastCalledWith(true);
+    expect(mockCallback).toHaveBeenLastCalledWith(elementsMock);
     childContext.addElementsLoadListener(mockCallback);
     expect(mockCallback).toHaveBeenCalledTimes(2);
-    expect(mockCallback).toHaveBeenCalledWith(true);
+    expect(mockCallback).toHaveBeenCalledWith(elementsMock);
+  });
+
+  it('with sync context, elements is instantiated right away', () => {
+    const syncContext = {
+      tag: 'sync',
+      stripe: stripeMock,
+    };
+    const wrapper = mount(
+      <Elements>
+        <div />
+      </Elements>,
+      {context: syncContext}
+    );
+    const childContext = wrapper.instance().getChildContext();
+
+    expect(childContext.elements).not.toBe(null);
   });
 
   it('with async context: addElementsLoadListener returns the same elements instance ', () => {
@@ -79,15 +97,17 @@ describe('Elements', () => {
     );
     const childContext = wrapper.instance().getChildContext();
 
+    expect(childContext.elements).toBe(null);
+
     const a = new Promise((resolve) =>
       childContext.addElementsLoadListener((first) => {
-        expect(first).toEqual(true);
+        expect(first).toEqual(elementsMock);
         resolve();
       })
     );
     const b = new Promise((resolve) =>
       childContext.addElementsLoadListener((second) => {
-        expect(second).toEqual(true);
+        expect(second).toEqual(elementsMock);
         resolve();
       })
     );

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -329,6 +329,7 @@ Please be sure the component that calls createSource or createToken is within an
         <WrappedComponent
           {...this.props}
           stripe={this.state.stripe}
+          elements={this.context.elements}
           ref={
             withRef
               ? (c) => {

--- a/src/components/inject.js
+++ b/src/components/inject.js
@@ -22,11 +22,16 @@ type WrappedStripeShape = {
   createPaymentMethod: Function,
   handleCardPayment: Function,
   handleCardSetup: Function,
+  confirmCardPayment: Function,
+  confirmCardSetup: Function,
 };
 
 type State = {stripe: WrappedStripeShape | null};
 
-export type InjectedProps = {stripe: WrappedStripeShape | null};
+export type InjectedProps = {
+  stripe: WrappedStripeShape | null,
+  elements: ElementsShape | null,
+};
 
 // react-redux does a bunch of stuff with pure components / checking if it needs to re-render.
 // not sure if we need to do the same.
@@ -226,6 +231,10 @@ Please be sure the component that calls createSource or createToken is within an
       elementOrData?: mixed,
       maybeData?: mixed
     ) => {
+      if (paymentMethodType && typeof paymentMethodType === 'object') {
+        return stripe.createPaymentMethod(paymentMethodType);
+      }
+
       if (!paymentMethodType || typeof paymentMethodType !== 'string') {
         throw new Error(
           `Invalid PaymentMethod type passed to createPaymentMethod. Expected a string, got ${typeof paymentMethodType}.`

--- a/src/components/inject.test.js
+++ b/src/components/inject.test.js
@@ -14,6 +14,7 @@ describe('injectStripe()', () => {
   let handleCardSetup;
   let elementMock;
   let rawElementMock;
+  let elementsMock;
 
   // Before ALL tests (sync or async)
   beforeEach(() => {
@@ -22,6 +23,7 @@ describe('injectStripe()', () => {
     createPaymentMethod = jest.fn();
     handleCardPayment = jest.fn();
     handleCardSetup = jest.fn();
+    elementsMock = {};
     rawElementMock = {
       _frame: {
         id: 'id',
@@ -53,6 +55,7 @@ describe('injectStripe()', () => {
           handleCardPayment,
           handleCardSetup,
         },
+        elements: elementsMock,
         getRegisteredElements: () => [elementMock],
       };
     });
@@ -114,6 +117,17 @@ describe('injectStripe()', () => {
       expect(props).toHaveProperty('stripe.createToken');
       expect(props).toHaveProperty('stripe.createPaymentMethod');
       expect(props).toHaveProperty('stripe.handleCardPayment');
+    });
+
+    it('renders <WrappedComponent> with `elements` prop', () => {
+      const Injected = injectStripe(WrappedComponent);
+
+      const wrapper = shallow(<Injected />, {
+        context,
+      });
+
+      const props = wrapper.props();
+      expect(props.elements).toBe(elementsMock);
     });
 
     it('props.stripe.createToken calls createToken with element and empty options when called with no arguments', () => {

--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -13,7 +13,18 @@ declare type ElementShape = {
 
 declare type ElementsShape = {
   create: (type: string, options: MixedObject) => ElementShape,
+  getElement: (type: string) => null | ElementShape,
 };
+
+type ConfirmSetupFn = (
+  clientSecret: string,
+  options?: mixed
+) => Promise<{setupIntent?: MixedObject, error?: MixedObject}>;
+
+type ConfirmPaymentFn = (
+  clientSecret: string,
+  options?: mixed
+) => Promise<{paymentIntent?: MixedObject, error?: MixedObject}>;
 
 declare type StripeShape = {
   elements: (options: MixedObject) => ElementsShape,
@@ -26,9 +37,9 @@ declare type StripeShape = {
     options: mixed
   ) => Promise<{token?: MixedObject, error?: MixedObject}>,
   createPaymentMethod: (
-    type: string,
-    element: ElementShape | MixedObject,
-    data: mixed
+    type: mixed,
+    element?: ElementShape | MixedObject,
+    data?: mixed
   ) => Promise<{paymentMethod?: MixedObject, error?: MixedObject}>,
   handleCardPayment: (
     clientSecret: string,
@@ -40,4 +51,9 @@ declare type StripeShape = {
     element: mixed,
     options: mixed
   ) => Promise<{setupIntent?: MixedObject, error?: MixedObject}>,
+  confirmCardPayment: ConfirmPaymentFn,
+  confirmCardSetup: ConfirmSetupFn,
+  confirmIdealPayment: ConfirmPaymentFn,
+  confirmSepaDebitPayment: ConfirmPaymentFn,
+  confirmSepaDebitSetup: ConfirmSetupFn,
 };


### PR DESCRIPTION
### Summary & motivation

* inject Elements with `injectStripe` so that users will be able to call `elements.getElement()`.
* update the documentation with `confirmCardPayment` and `confirmCardSetup` examples, remove the deprecated `handle*` docs.
* support both the new and the old signature for `createPaymentMethod`, move all the docs and examples to use the new signature.
* update the types
* some misc. readme improvements

### Testing & documentation

I wrote unit tests. I updated the demos and made sure they worked.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
