### PR TITLE
Fix changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,6 @@ this.props.stripe
     ): Promise<{error?: Object, setupIntent?: Object}>
   ```
 
-````
-
 For more information, please review the Stripe Docs:
 
 - [`stripe.handleCardSetup`](https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup)
@@ -411,4 +409,3 @@ Initial release! Support for:
   - CardExpiryElement
   - CardCVCElement
   - PostalCodeElement
-````


### PR DESCRIPTION
Remove errant fenced code block that was causing the half the changelog to be formatted as code.