### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-dom": "16.9",
     "react-test-renderer": "16.9",
     "rimraf": "^2.6.2",
-    "webpack": "^4.29.0",
+    "webpack": "^4.41.2",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14"
   },


### PR DESCRIPTION
### Summary & motivation

Github provided us with a security warning because we were pulling in a vulnerable version of the serialize-javascript library (v1.6.1) We don't have a direct dependency on serialize-javascript. But 
`yarn why serialize-javascript` showed that we were pulling it in through a dependency on webpack. So I upgraded to the newest version of webpack that's at least 30 days old, re-ran `yarn why serialize-javascript` and saw that we're now dependent on v2.1.2, which contains the security fix.

### Testing & documentation

I have not tested this. I'm not familiar with this codebase. 

I'm in the process of looking at how we should handle automated alerts like this. I'm happy to talk more about how to handle these kinds of alerts in a scalable way going forward. This won't be the last time we encounter vulnerable libraries. 