### PR TITLE
Add auBankAccount element

### DIFF
--- a/src/decls/Stripe.js
+++ b/src/decls/Stripe.js
@@ -56,4 +56,6 @@ declare type StripeShape = {
   confirmIdealPayment: ConfirmPaymentFn,
   confirmSepaDebitPayment: ConfirmPaymentFn,
   confirmSepaDebitSetup: ConfirmSetupFn,
+  confirmAuBecsDebitPayment: ConfirmPaymentFn,
+  confirmAuBecsDebitSetup: ConfirmSetupFn,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,10 @@ const IbanElement = Element('iban', {
 const IdealBankElement = Element('idealBank', {impliedSourceType: 'ideal'});
 
 // AU Bank Account
-const AuBankAccountElement = Element('auBankAccount', {impliedSourceType: 'au_becs_debit', impliedPaymentMethodType: 'au_becs_debit'});
+const AuBankAccountElement = Element('auBankAccount', {
+  impliedSourceType: 'au_becs_debit',
+  impliedPaymentMethodType: 'au_becs_debit',
+});
 
 export {
   StripeProvider,

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ const IbanElement = Element('iban', {
 // iDEAL Bank
 const IdealBankElement = Element('idealBank', {impliedSourceType: 'ideal'});
 
+// AU Bank Account
+const AuBankAccountElement = Element('auBankAccount', {impliedSourceType: 'au_becs_debit', impliedPaymentMethodType: 'au_becs_debit'});
+
 export {
   StripeProvider,
   injectStripe,
@@ -48,4 +51,5 @@ export {
   PaymentRequestButtonElement,
   IbanElement,
   IdealBankElement,
+  AuBankAccountElement,
 };


### PR DESCRIPTION
### Summary & motivation

Add support for the (beta) auBankAccount component.

### API review

Adds an `auBankAccount` component, `confirmAuBecsDebitPayment` method, and `confirmAuBecsDebitSetup` method.

### Testing & documentation

Manually tested. Documentation is planned to be part of the beta documentation.
