### PR TITLE
add auBankAccount and fpxBank elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,14 @@ const IbanElement = Element('iban', {
 // iDEAL Bank
 const IdealBankElement = Element('idealBank', {impliedSourceType: 'ideal'});
 
+// fpx Bank
+const FpxBankElement = Element('fpxBank');
+
+// auBankAccount
+// Requires beta access. Contact Stripe support for more information:
+// https://support.stripe.com
+const AuBankAccountElement = Element('auBankAccount');
+
 export {
   StripeProvider,
   injectStripe,
@@ -48,4 +56,6 @@ export {
   PaymentRequestButtonElement,
   IbanElement,
   IdealBankElement,
+  FpxBankElement,
+  AuBankAccountElement,
 };


### PR DESCRIPTION
### Summary & motivation

Add the `auBankAccount` and `fpxBank` elements. These elements will not have automatic Element detection/insertion. To use them you will need to use `elements.getElement` and pass them directly to other Stripe.js methods (e.g. `stripe.confirmFpxPayment`):

```jsx
const FpxForm = injectStripe(({stripe, elements}) => {
  const handleSubmit = async (event) => {
    event.preventDefault();
    const {error} = await stripe.confirmFpxPayment('{{CLIENT_SECRET}}', {
      payment_method: {
        fpx: elements.getElement('fpxBank'),
      },
    });
  }

  return (
    <form onSubmit={handleSubmit}>
      <FpxBankElement accountHolderType="individual" />
      <button>Pay</button>
    </form>
  );
});
```
<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->
