### PR TITLE
register all elements

### DIFF
--- a/src/components/Element.js
+++ b/src/components/Element.js
@@ -79,18 +79,12 @@ const Element = (
         element.mount(this._ref);
 
         // Register Element for automatic token / source / paymentMethod creation
-        if (
-          hocOptions.impliedTokenType ||
-          hocOptions.impliedSourceType ||
+        this.context.registerElement(
+          element,
+          hocOptions.impliedTokenType,
+          hocOptions.impliedSourceType,
           hocOptions.impliedPaymentMethodType
-        ) {
-          this.context.registerElement(
-            element,
-            hocOptions.impliedTokenType,
-            hocOptions.impliedSourceType,
-            hocOptions.impliedPaymentMethodType
-          );
-        }
+        );
       });
     }
 

--- a/src/components/Element.test.js
+++ b/src/components/Element.test.js
@@ -73,11 +73,17 @@ describe('Element', () => {
     expect(context.unregisterElement).toHaveBeenCalledWith(elementMock);
   });
 
-  it('should call the right hooks for a non-registered Element', () => {
+  it('should call the right hooks for a non-auto-detected Element', () => {
     const TestElement = Element('test');
     const element = mount(<TestElement onChange={jest.fn()} />, {context});
 
-    expect(context.registerElement).toHaveBeenCalledTimes(0);
+    expect(context.registerElement).toHaveBeenCalledTimes(1);
+    expect(context.registerElement).toHaveBeenCalledWith(
+      elementMock,
+      undefined,
+      undefined,
+      undefined
+    );
 
     element.unmount();
     expect(elementMock.destroy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Summary & motivation
Fix a bug where `elements` is not injected when using async Stripe and only mounting a `CardCvcElement` or `CardExpiry` Element. 

I fixed this by always registering all Elements. Previously, we skipped this for Elements that are not auto-detected. This change ensures that `state` is always updated after `Elements` is instantiated which triggers a re-render on components wrapped with `inject`.

Registering these Elements should not have any unintended consequences. When we look up Elements for auto-detection in methods like `createToken` we always filter by an `implied*Type`. The newly registered Elements will not have any `implied*Type` and will always be filtered out.

This better fix would involve moving `_elements` to `state`. This is a much larger change that seemed to have some potential downstream implications that I wanted to avoid.

<!-- Simple summary of what the code does or what you have changed. If this is a visual change, please include a screenshot/GIF. -->

### Testing & documentation
I updated the unit tests and tested this manually using the async demo.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". As a suggestion: double check your change works with *Split Fields*. -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
